### PR TITLE
Fixed a bug where the `Required` annotation was not enforced when loa…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+#### Version 1.8.2 (TBD)
+* Fixed a bug where the `Required` annotation was not enforced when loading data from the database. If a record was modified outside of Runway such that a required field was nullified, Runway would previously load the record without enforcing the constraint. This caused applications to encounter some unexpected `NullPointerException`s.
+
 #### Version 1.8.1 (April 20, 2020)
 * Fixed a bug that allowed for dynamically `set`ing an intrinsic attribute of a `Record` with a value of an invalid type. In this scenario, Runway should have thrown an error, but it didn't. While the value with the invalid type was not persisted when saving the Record, it was return on intermediate reads of the Record.
 

--- a/src/main/java/com/cinchapi/runway/Record.java
+++ b/src/main/java/com/cinchapi/runway/Record.java
@@ -1241,6 +1241,12 @@ public abstract class Record implements Comparable<Record> {
                     if(value != null) {
                         field.set(this, value);
                     }
+                    else if(value == null
+                            && field.isAnnotationPresent(Required.class)) {
+                        throw new IllegalStateException("Record " + id
+                                + " cannot be loaded because '" + key
+                                + "' is a required field, but no value is present in the database.");
+                    }
                     else {
                         // no-op; NOTE: Java doesn't allow primitive types to
                         // hold null values

--- a/src/test/java/com/cinchapi/runway/RecordTest.java
+++ b/src/test/java/com/cinchapi/runway/RecordTest.java
@@ -41,9 +41,6 @@ import com.cinchapi.concourse.lang.Criteria;
 import com.cinchapi.concourse.test.ClientServerTest;
 import com.cinchapi.concourse.thrift.Operator;
 import com.cinchapi.concourse.util.Random;
-import com.cinchapi.runway.Record;
-import com.cinchapi.runway.Required;
-import com.cinchapi.runway.Unique;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -810,6 +807,47 @@ public class RecordTest extends ClientServerTest {
             Assert.assertTrue(true);
         }
         Assert.assertNotEquals("10", mock.age);
+    }
+    
+    @Test(expected = IllegalStateException.class)
+    public void testRequiredConstraintEnforcedOnExplicitLoad() {
+        Mock mock = new Mock();
+        mock.name = "Jeff Nelson";
+        mock.age = 32;
+        mock.save();
+        Concourse concourse = Concourse.at().port(server.getClientPort()).connect();
+        try {
+            concourse.clear("name", mock.id());
+        }
+        finally {
+            concourse.close();
+        }
+        mock = runway.load(Mock.class, mock.id());     
+    }
+    
+    @Test(expected = IllegalStateException.class)
+    public void testRequiredConstraintEnforcedOnImplicitLoad() {
+        for(int i = 0; i < Random.getScaleCount(); ++i) {
+            Mock m = new Mock();
+            m.name = Random.getSimpleString();
+            m.age = i;
+            m.save();
+        }
+        Mock mock = new Mock();
+        mock.name = "Jeff Nelson";
+        mock.age = 32;
+        mock.save();
+        Concourse concourse = Concourse.at().port(server.getClientPort()).connect();
+        try {
+            concourse.clear("name", mock.id());
+        }
+        finally {
+            concourse.close();
+        }    
+        Set<Mock> mocks = runway.find(Mock.class, Criteria.where().key("age").operator(Operator.LESS_THAN_OR_EQUALS).value(32));
+        for(Mock m : mocks) {
+            System.out.println(m.name);
+        }
     }
 
     class Node extends Record {


### PR DESCRIPTION
…ding data from the database.

If a record was modified outside of Runway such that a required field was nullified, Runway would previously load the record without enforcing the constraint. This caused applications to encounter some unexpected `NullPointerException`s.