### PR TITLE
Add @Computed and @Derived annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-#### Version 1.9.5 (TBD)
-* Fixed a regression that casued a `NullPointerException` to be thrown when a `null` intrinsic, `derived()` or `computed()` value was encountered while performing local `condition` evaluation. 
+#### Version 1.10.0 (TBD)
+* Added `@Computed` and `@Derived` annotations that can be applied to methods to mark them as returning `computed` and `derived` properties, respectively. These annotations are meant to be used in lieu of the `#computed()` and `#derived()` methods, which are now deprecated
+* Fixed a regression that casued a `NullPointerException` to be thrown when a `null` intrinsic, `derived` or `computed` value was encountered while performing local `condition` evaluation. 
 
 #### Version 1.9.4 (July 22, 2022)
 * Fixed a bug that occurred when using *pre-select* to load a Record containing a reference field whose **declared** type is the parent class of a descendant class with additionally defined fields and the stored value for that field is an instance of that descendant class. In this case, the pre-select logic did not load data for the descendant defined fields, which resulted in unexpected `NullPointerException` regressions or an overall inability to load those Records if the descendant defined field was annotated as `Required`.

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ repositories {
 
 
 // Set the version for all Concourse dependencies
-ext.concourseVersion = '0.11.2'
+ext.concourseVersion = '0.11.5'
 
 dependencies {
 	compile 'com.google.guava:guava:25.1-jre'

--- a/src/main/java/com/cinchapi/runway/Computed.java
+++ b/src/main/java/com/cinchapi/runway/Computed.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2013-2019 Cinchapi Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cinchapi.runway;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A marker to indicate that a method provides a <strong>computed</strong>
+ * property.
+ * <p>
+ * A computed property is additional information that is not directly stored in
+ * the database, but can be computed, on-demand.
+ * </p>
+ * <p>
+ * Unlike {@link Derived derived} attributes, computed data is generally
+ * expensive to generate and should only be calculated when explicitly
+ * requested.
+ * </p>
+ * <p>
+ * NOTE: Computed attributes are never cached. Each time one is requested,
+ * the computation that generates the value is done anew.
+ * </p>
+ * 
+ * @author Jeff Nelson
+ */
+@Documented
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Computed {
+
+    /**
+     * The name of computed property. By default, the name of the annotated
+     * method is used.
+     * 
+     * @return the name of the computed property
+     */
+    String value() default "";
+}

--- a/src/main/java/com/cinchapi/runway/Derived.java
+++ b/src/main/java/com/cinchapi/runway/Derived.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2013-2019 Cinchapi Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cinchapi.runway;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A marker to indicate that a method provides a <strong>derived</strong>
+ * property.
+ * <p>
+ * A derived property is additional information that is not directly stored in
+ * the database, but can be inferred based on {@link Record#intrinsic()
+ * intrinsic} properties.
+ * </p>
+ * 
+ * @author Jeff Nelson
+ */
+@Documented
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Derived {
+
+    /**
+     * The name of derived property. By default, the name of the annotated
+     * method is used.
+     * 
+     * @return the name of the derived property
+     */
+    String value() default "";
+}

--- a/src/test/java/com/cinchapi/runway/RecordTest.java
+++ b/src/test/java/com/cinchapi/runway/RecordTest.java
@@ -317,12 +317,23 @@ public class RecordTest extends ClientServerTest {
         Assert.assertEquals("Georgia", state);
         Assert.assertTrue(end - start >= 1000);
     }
+    
+    @Test
+    public void testGetAnnotatedComputedValue() {
+        Rock rock = new Rock();
+        long start = System.currentTimeMillis();
+        String county = rock.get("county");
+        long end = System.currentTimeMillis();
+        Assert.assertEquals("Fulton", county);
+        Assert.assertTrue(end - start >= 1000);
+    }
 
     @Test
-    public void testComputedValueIncludedInGetAll() {
+    public void testAnnotatedComputedValueIncludedInGetAll() {
         Rock rock = new Rock();
         Map<String, Object> data = rock.map();
         Assert.assertTrue(data.containsKey("state"));
+        Assert.assertTrue(data.containsKey("county"));
     }
 
     @Test
@@ -331,6 +342,14 @@ public class RecordTest extends ClientServerTest {
         Map<String, Object> data = bock.map("-state");
         System.out.println(data);
         Assert.assertFalse(data.containsKey("state"));
+    }
+    
+    @Test
+    public void testAnnotatedComputedValueNotComputedIfNotNecessary() {
+        Bock bock = new Bock();
+        Map<String, Object> data = bock.map("-county");
+        System.out.println(data);
+        Assert.assertFalse(data.containsKey("county"));
     }
 
     @Test
@@ -1048,6 +1067,13 @@ public class RecordTest extends ClientServerTest {
         mmap = a.mmap("label");
         Assert.assertFalse(mmap.containsKey("friends"));
     }
+    
+    @Test
+    public void testGetAnnotatedDerivedProperty() {
+        Nock nock = new Nock();
+        Assert.assertEquals("Atlanta", nock.get("area"));
+        Assert.assertEquals("30327", nock.get("zipcode"));
+    }
 
     // @Test
     // public void testReconcileCollectionPrimitiveValues() {
@@ -1206,6 +1232,16 @@ public class RecordTest extends ClientServerTest {
     }
 
     class Nock extends Mock {
+        
+        @Derived
+        public String zipcode() {
+            return "30327";
+        }
+        
+        @Derived("area")
+        public String city() {
+            return "Atlanta";
+        }
 
         @Override
         public Map<String, Object> derived() {
@@ -1215,6 +1251,15 @@ public class RecordTest extends ClientServerTest {
     }
 
     class Rock extends Nock {
+        
+        @Computed("county")
+        public String county() {
+            long stop = System.currentTimeMillis() + 1000;
+            while (System.currentTimeMillis() < stop) {
+                continue;
+            }
+            return "Fulton";
+        }
 
         @Override
         public Map<String, Supplier<Object>> computed() {

--- a/src/test/java/com/cinchapi/runway/RecordTest.java
+++ b/src/test/java/com/cinchapi/runway/RecordTest.java
@@ -340,7 +340,6 @@ public class RecordTest extends ClientServerTest {
     public void testComputedValueNotComputedIfNotNecessary() {
         Bock bock = new Bock();
         Map<String, Object> data = bock.map("-state");
-        System.out.println(data);
         Assert.assertFalse(data.containsKey("state"));
     }
     
@@ -348,7 +347,6 @@ public class RecordTest extends ClientServerTest {
     public void testAnnotatedComputedValueNotComputedIfNotNecessary() {
         Bock bock = new Bock();
         Map<String, Object> data = bock.map("-county");
-        System.out.println(data);
         Assert.assertFalse(data.containsKey("county"));
     }
 


### PR DESCRIPTION
…ethods to mark them as returning `computed` and `derived` properties, respectively. These annotations are meant to be used in lieu of the `#computed()` and `#derived()` methods, which are now deprecated