### PR TITLE
[GH-52] Optimize computed value generation to avoid redundant computation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ New deletion hooks are available to ensure automatic referential integrity when 
 
 ##### Improvements
 * Improved Runway's bulk loading functionality to ensure that the same object reference is used for a linked Record that exists as a value in multiple records. Previously, in a single bulk load operation, Runway would create a new Java object for EVERY loaded reference, regardless of whether that referenced object was already encountered earlier in the load, which created unnecessary heap bloat. This optimization reduces memory usage and ensures object identity is maintained across references to the same record within a single load operation.
+* Optimized computed value generation to ensure values are only computed once per map operation. Previously, when filtering null values during serialization, computed values were unnecessarily generated twice - once during the null check and again when adding to the result map. This improvement caches computed values within each map operation while still ensuring fresh values are generated for each new operation.
+
 
 ##### Bug Fixes
 * Fixed a regression that casued a `NullPointerException` to be thrown when a `null` intrinsic, `derived` or `computed` value was encountered while performing local `condition` evaluation. 

--- a/src/main/java/com/cinchapi/runway/util/ComputedEntry.java
+++ b/src/main/java/com/cinchapi/runway/util/ComputedEntry.java
@@ -36,6 +36,11 @@ public class ComputedEntry<K, V> implements Entry<K, V> {
     private final Supplier<V> valueSupplier;
 
     /**
+     * A cached of the {@link #valueSupplier computed} value.
+     */
+    private transient V value = null;
+
+    /**
      * Construct a new instance.
      * 
      * @param entry
@@ -62,7 +67,10 @@ public class ComputedEntry<K, V> implements Entry<K, V> {
 
     @Override
     public V getValue() {
-        return valueSupplier.get();
+        if(value == null) {
+            value = valueSupplier.get();
+        }
+        return value;
     }
 
     @Override

--- a/src/test/java/com/cinchapi/runway/RecordComputedValueTest.java
+++ b/src/test/java/com/cinchapi/runway/RecordComputedValueTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2013-2019 Cinchapi Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cinchapi.runway;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.cinchapi.concourse.test.ClientServerTest;
+
+/**
+ * Tests for computed values in {@link Record}.
+ */
+public class RecordComputedValueTest extends ClientServerTest {
+
+    @Test
+    public void testComputedValueGeneratedOnlyOncePerMapAndNotCached() {
+        Counter counter = new Counter();
+
+        // Map operation should only compute the value once
+        Map<String, Object> data = counter.map();
+        Assert.assertEquals(1, data.get("count"));
+
+        // Second map operation should increment the count again
+        // (proving we don't cache between operations)
+        data = counter.map();
+        Assert.assertEquals(2, data.get("count"));
+    }
+
+    @Override
+    protected String getServerVersion() {
+        return Testing.CONCOURSE_VERSION;
+    }
+
+    class Counter extends Record {
+        private final AtomicInteger count = new AtomicInteger(0);
+
+        @Computed
+        public int count() {
+            return count.incrementAndGet();
+        }
+    }
+
+
+}


### PR DESCRIPTION
Fixed an issue where computed values were being generated twice during map operations when filtering null values. The first computation occurred during the null check and the second when adding the value to the result map. Modified ComputedEntry to cache the computed value within each instance, ensuring values are only computed once per map operation while still generating fresh values for each new operation.

Added comprehensive tests to verify the optimization works correctly.