### PR TITLE
Fix count any bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,9 @@ Fixed a bug where there was inconsistent priorities in the order of data returne
 * **Record Reference Replacement**: Added a new `replace(Record find, Record replace)` method to the `Record` class that recursively replaces all references to a specific record instance with another record throughout the object graph, maintaining referential integrity while handling nested records, deferred references, and sequences.
 * **Metadata Interface**: Added a new `Metadata` interface that provides implementing Record types with computed properties to obtain the Record's timestamps for creation and most recent update (including the ability to filter for most recent update to specific keys).
 
+#### Version 1.10.1 (October 1, 2025)
+* Fixed a bug that caused the `countAny(Class, Criteria, Realms)` method to incorrectly count records within only the specified class instead of across the entire class hierarchy.
+
 #### Version 1.10.0 (May 11, 2025)
 
 ##### Deletion Hooks

--- a/src/main/java/com/cinchapi/runway/Runway.java
+++ b/src/main/java/com/cinchapi/runway/Runway.java
@@ -413,7 +413,7 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
             Realms realms) {
         if(Record.isDatabaseResolvableCondition(clazz, criteria)) {
             return count($Criteria.amongRealms(realms,
-                    $Criteria.withinClass(clazz, criteria)));
+                    $Criteria.accrossClassHierachy(clazz, criteria)));
         }
         else {
             return filterAny(clazz, criteria, NO_ORDER, NO_PAGINATION, realms)


### PR DESCRIPTION
Fixed a bug that caused the `countAny(Class, Criteria, Realms)` method to incorrectly count records within only the specified class instead of across the entire class hierarchy.