### PR TITLE
Ad-Hoc Record and Federated Data Source Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,29 @@ Fixed a bug where there was inconsistent priorities in the order of data returne
 * **Previous Inconsistency**: Previously, `get()` used the order: dynamic → intrinsic → derived → computed, while `map()` used: dynamic → intrinsic → computed → derived
 * **Impact**: This fix resolves issues that occurred when the same key was used in both computed and derived data, ensuring consistent behavior across all data access methods
 
+##### Ad-Hoc Records and Federated Data Sources
+Runway now provides infrastructure for serving non-persistent, in-memory data through the standard `DatabaseInterface` API. This enables seamless integration of programmatic data sources with persistent database records.
+
+* **`AdHocRecord`**: A read-only `Record` base class for temporary, non-persistent data structures. Subclasses define their schema through fields like regular Records, but attempts to persist or modify an `AdHocRecord` will throw an `UnsupportedOperationException`. This is useful for generating report-like structures, aggregated data views, or other read-only data representations that need to be compatible with the application's data access patterns.
+
+* **`AdHocDatabase`**: A `DatabaseInterface` implementation that serves a single `AdHocRecord` type from an in-memory data source. Data is supplied via a `Supplier` that is evaluated on each query, allowing for dynamic or computed data. The `AdHocDatabase` supports full query capabilities including `Criteria` filtering, `Order` sorting, and `Page` pagination—all resolved in-memory against the supplied collection.
+
+* **`FederatedRunway`**: A `DatabaseInterface` implementation that unifies persistent data from `Runway` with ad-hoc data from one or more `AdHocDatabase` instances. Queries are automatically routed to the appropriate data source based on the requested class. This enables applications to expose both persistent and programmatic data through a single, unified API.
+  ```java
+  AdHocDatabase<ReportRecord> reports = new AdHocDatabase<>(
+      ReportRecord.class, () -> generateReports());
+
+  FederatedRunway db = FederatedRunway.builder()
+      .defaultTo(runway)
+      .register(reports)
+      .build();
+
+  // Routes to Runway
+  db.load(User.class);
+  // Routes to AdHocDatabase
+  db.find(ReportRecord.class, criteria);
+  ```
+
 ##### Other Improvements
 * **Record Reference Replacement**: Added a new `replace(Record find, Record replace)` method to the `Record` class that recursively replaces all references to a specific record instance with another record throughout the object graph, maintaining referential integrity while handling nested records, deferred references, and sequences.
 * **Metadata Interface**: Added a new `Metadata` interface that provides implementing Record types with computed properties to obtain the Record's timestamps for creation and most recent update (including the ability to filter for most recent update to specific keys).

--- a/src/main/java/com/cinchapi/runway/AdHocDatabase.java
+++ b/src/main/java/com/cinchapi/runway/AdHocDatabase.java
@@ -1,0 +1,488 @@
+/*
+ * Copyright (c) 2013-2025 Cinchapi Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cinchapi.runway;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
+
+import com.cinchapi.ccl.syntax.ConditionTree;
+import com.cinchapi.common.base.Array;
+import com.cinchapi.concourse.DuplicateEntryException;
+import com.cinchapi.concourse.lang.ConcourseCompiler;
+import com.cinchapi.concourse.lang.Criteria;
+import com.cinchapi.concourse.lang.paginate.Page;
+import com.cinchapi.concourse.lang.sort.Direction;
+import com.cinchapi.concourse.lang.sort.Order;
+import com.cinchapi.concourse.lang.sort.OrderComponent;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+
+/**
+ * A {@link DatabaseInterface} that serves a single {@link AdHocRecord} type
+ * from an in-memory data source.
+ * <p>
+ * An {@link AdHocDatabase} bridges programmatic data sources with Runway's
+ * query interface. Data is supplied via a {@link Supplier} that is evaluated
+ * on each query, allowing for dynamic or computed data.
+ * </p>
+ * <p>
+ * Queries for the registered {@link AdHocRecord} type are resolved in-memory
+ * against the supplied collection. Queries for any other type return empty
+ * results.
+ * </p>
+ * <p>
+ * To combine multiple {@link AdHocDatabase AdHocDatabases} or integrate with
+ * a persistent database, use {@link FederatedRunway}.
+ * </p>
+ *
+ * @param <T> the type of {@link AdHocRecord} served by this database
+ * @author Jeff Nelson
+ */
+public class AdHocDatabase<T extends AdHocRecord> implements DatabaseInterface {
+
+    /**
+     * The class of {@link AdHocRecord} served by this database.
+     */
+    private final Class<T> clazz;
+
+    /**
+     * The data source for this database.
+     */
+    private final Supplier<Collection<T>> supplier;
+
+    /**
+     * Construct a new instance.
+     *
+     * @param clazz the {@link AdHocRecord} class this database serves
+     * @param supplier the data source; invoked on each query
+     */
+    public AdHocDatabase(Class<T> clazz, Supplier<Collection<T>> supplier) {
+        this.clazz = clazz;
+        this.supplier = supplier;
+    }
+
+    @Override
+    public <R extends Record> Set<R> find(Class<R> clazz, Criteria criteria,
+            Order order, Page page, Realms realms) {
+        if(handles(clazz)) {
+            Set<R> filtered = doFind(criteria);
+            filtered = sort(filtered, order);
+            return paginate(filtered, page);
+        }
+        else {
+            return ImmutableSet.of();
+        }
+    }
+
+    @Override
+    public <R extends Record> Set<R> find(Class<R> clazz, Criteria criteria,
+            Order order, Realms realms) {
+        if(handles(clazz)) {
+            Set<R> filtered = doFind(criteria);
+            return sort(filtered, order);
+        }
+        else {
+            return ImmutableSet.of();
+        }
+    }
+
+    @Override
+    public <R extends Record> Set<R> find(Class<R> clazz, Criteria criteria,
+            Page page, Realms realms) {
+        if(handles(clazz)) {
+            Set<R> filtered = doFind(criteria);
+            return paginate(filtered, page);
+        }
+        else {
+            return ImmutableSet.of();
+        }
+    }
+
+    @Override
+    public <R extends Record> Set<R> find(Class<R> clazz, Criteria criteria,
+            Realms realms) {
+        if(handles(clazz)) {
+            return doFind(criteria);
+        }
+        else {
+            return ImmutableSet.of();
+        }
+    }
+
+    @Override
+    public <R extends Record> Set<R> findAny(Class<R> clazz, Criteria criteria,
+            Order order, Page page, Realms realms) {
+        if(handlesHierarchy(clazz)) {
+            Set<R> filtered = doFindAny(clazz, criteria);
+            filtered = sort(filtered, order);
+            return paginate(filtered, page);
+        }
+        else {
+            return ImmutableSet.of();
+        }
+    }
+
+    @Override
+    public <R extends Record> Set<R> findAny(Class<R> clazz, Criteria criteria,
+            Order order, Realms realms) {
+        if(handlesHierarchy(clazz)) {
+            Set<R> filtered = doFindAny(clazz, criteria);
+            return sort(filtered, order);
+        }
+        else {
+            return ImmutableSet.of();
+        }
+    }
+
+    @Override
+    public <R extends Record> Set<R> findAny(Class<R> clazz, Criteria criteria,
+            Page page, Realms realms) {
+        if(handlesHierarchy(clazz)) {
+            Set<R> filtered = doFindAny(clazz, criteria);
+            return paginate(filtered, page);
+        }
+        else {
+            return ImmutableSet.of();
+        }
+    }
+
+    @Override
+    public <R extends Record> Set<R> findAny(Class<R> clazz, Criteria criteria,
+            Realms realms) {
+        if(handlesHierarchy(clazz)) {
+            return doFindAny(clazz, criteria);
+        }
+        else {
+            return ImmutableSet.of();
+        }
+    }
+
+    @Override
+    public <R extends Record> R findAnyUnique(Class<R> clazz, Criteria criteria,
+            Realms realms) {
+        Set<R> results = findAny(clazz, criteria, realms);
+        return unique(results, clazz, criteria);
+    }
+
+    @Override
+    public <R extends Record> R findUnique(Class<R> clazz, Criteria criteria,
+            Realms realms) {
+        Set<R> results = find(clazz, criteria, realms);
+        return unique(results, clazz, criteria);
+    }
+
+    @Override
+    public <R extends Record> R load(Class<R> clazz, long id, Realms realms) {
+        if(handles(clazz)) {
+            return doLoad(id);
+        }
+        else {
+            return null;
+        }
+    }
+
+    @Override
+    public <R extends Record> Set<R> load(Class<R> clazz, Order order,
+            Page page, Realms realms) {
+        if(handles(clazz)) {
+            Set<R> all = doLoad();
+            all = sort(all, order);
+            return paginate(all, page);
+        }
+        else {
+            return ImmutableSet.of();
+        }
+    }
+
+    @Override
+    public <R extends Record> Set<R> load(Class<R> clazz, Order order,
+            Realms realms) {
+        if(handles(clazz)) {
+            return sort(doLoad(), order);
+        }
+        else {
+            return ImmutableSet.of();
+        }
+    }
+
+    @Override
+    public <R extends Record> Set<R> load(Class<R> clazz, Page page,
+            Realms realms) {
+        if(handles(clazz)) {
+            return paginate(doLoad(), page);
+        }
+        else {
+            return ImmutableSet.of();
+        }
+    }
+
+    @Override
+    public <R extends Record> Set<R> load(Class<R> clazz, Realms realms) {
+        if(handles(clazz)) {
+            return doLoad();
+        }
+        else {
+            return ImmutableSet.of();
+        }
+    }
+
+    @Override
+    public <R extends Record> Set<R> loadAny(Class<R> clazz, Order order,
+            Page page, Realms realms) {
+        if(handlesHierarchy(clazz)) {
+            Set<R> all = doLoadAny(clazz);
+            all = sort(all, order);
+            return paginate(all, page);
+        }
+        else {
+            return ImmutableSet.of();
+        }
+    }
+
+    @Override
+    public <R extends Record> Set<R> loadAny(Class<R> clazz, Order order,
+            Realms realms) {
+        if(handlesHierarchy(clazz)) {
+            return sort(doLoadAny(clazz), order);
+        }
+        else {
+            return ImmutableSet.of();
+        }
+    }
+
+    @Override
+    public <R extends Record> Set<R> loadAny(Class<R> clazz, Page page,
+            Realms realms) {
+        if(handlesHierarchy(clazz)) {
+            return paginate(doLoadAny(clazz), page);
+        }
+        else {
+            return ImmutableSet.of();
+        }
+    }
+
+    @Override
+    public <R extends Record> Set<R> loadAny(Class<R> clazz, Realms realms) {
+        if(handlesHierarchy(clazz)) {
+            return doLoadAny(clazz);
+        }
+        else {
+            return ImmutableSet.of();
+        }
+    }
+
+    /**
+     * Return the class of {@link AdHocRecord} served by this database.
+     *
+     * @return the registered class
+     */
+    public Class<T> registeredClass() {
+        return clazz;
+    }
+
+    /**
+     * Find all records matching the given criteria.
+     *
+     * @param criteria the filter criteria
+     * @return matching records
+     */
+    @SuppressWarnings("unchecked")
+    private <R extends Record> Set<R> doFind(Criteria criteria) {
+        Predicate<T> filter = createFilter(criteria);
+        return supplier.get().stream()
+                .filter(filter)
+                .map(record -> (R) record)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    /**
+     * Find all records in the class hierarchy matching the given criteria.
+     *
+     * @param requestedClass the requested class (may be a supertype)
+     * @param criteria the filter criteria
+     * @return matching records
+     */
+    @SuppressWarnings("unchecked")
+    private <R extends Record> Set<R> doFindAny(Class<R> requestedClass,
+            Criteria criteria) {
+        Predicate<T> filter = createFilter(criteria);
+        return supplier.get().stream()
+                .filter(record -> requestedClass.isInstance(record))
+                .filter(filter)
+                .map(record -> (R) record)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    /**
+     * Load all records from the supplier.
+     *
+     * @return all records
+     */
+    @SuppressWarnings("unchecked")
+    private <R extends Record> Set<R> doLoad() {
+        return supplier.get().stream()
+                .map(record -> (R) record)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    /**
+     * Load a specific record by id.
+     *
+     * @param id the record id
+     * @return the record, or {@code null} if not found
+     */
+    @SuppressWarnings("unchecked")
+    private <R extends Record> R doLoad(long id) {
+        return supplier.get().stream()
+                .filter(record -> record.id() == id)
+                .map(record -> (R) record)
+                .findFirst()
+                .orElse(null);
+    }
+
+    /**
+     * Load all records assignable to the requested class.
+     *
+     * @param requestedClass the requested class (may be a supertype)
+     * @return matching records
+     */
+    @SuppressWarnings("unchecked")
+    private <R extends Record> Set<R> doLoadAny(Class<R> requestedClass) {
+        return supplier.get().stream()
+                .filter(record -> requestedClass.isInstance(record))
+                .map(record -> (R) record)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    /**
+     * Create a filter predicate from the given criteria.
+     *
+     * @param criteria the filter criteria
+     * @return a predicate that tests records against the criteria
+     */
+    private Predicate<T> createFilter(Criteria criteria) {
+        ConcourseCompiler compiler = ConcourseCompiler.get();
+        ConditionTree ast = (ConditionTree) compiler.parse(criteria);
+        String[] keys = compiler.analyze(ast).keys()
+                .toArray(Array.containing());
+        return record -> compiler.evaluate(ast, record.mmap(keys));
+    }
+
+    /**
+     * Return {@code true} if this database handles the exact class.
+     *
+     * @param requestedClass the class being queried
+     * @return {@code true} if this database serves the class
+     */
+    private boolean handles(Class<?> requestedClass) {
+        return clazz.equals(requestedClass);
+    }
+
+    /**
+     * Return {@code true} if this database handles the class hierarchy.
+     *
+     * @param requestedClass the class being queried
+     * @return {@code true} if this database serves the class or a subclass
+     */
+    private boolean handlesHierarchy(Class<?> requestedClass) {
+        return requestedClass.isAssignableFrom(clazz);
+    }
+
+    /**
+     * Apply pagination to a set of records.
+     *
+     * @param records the records to paginate
+     * @param page the pagination parameters, or {@code null} for no pagination
+     * @return the paginated records
+     */
+    private <R extends Record> Set<R> paginate(Set<R> records,
+            @Nullable Page page) {
+        if(page == null) {
+            return records;
+        }
+        return records.stream()
+                .skip(page.skip())
+                .limit(page.limit())
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    /**
+     * Sort a set of records.
+     *
+     * @param records the records to sort
+     * @param order the sort order, or {@code null} for no sorting
+     * @return the sorted records
+     */
+    private <R extends Record> Set<R> sort(Set<R> records,
+            @Nullable Order order) {
+        if(order == null) {
+            return records;
+        }
+        List<String> orderSpec = toOrderSpec(order);
+        return DatabaseInterface.sort(records, orderSpec);
+    }
+
+    /**
+     * Convert an {@link Order} to a list-based order specification.
+     *
+     * @param order the order
+     * @return the list-based order specification
+     */
+    private static List<String> toOrderSpec(Order order) {
+        List<String> components = Lists.newArrayList();
+        for (OrderComponent component : order.spec()) {
+            String prefix = component.direction() == Direction.ASCENDING
+                    ? Record.SORT_DIRECTION_ASCENDING_PREFIX
+                    : Record.SORT_DIRECTION_DESCENDING_PREFIX;
+            components.add(prefix + component.key());
+        }
+        return components;
+    }
+
+    /**
+     * Verify that a result set contains exactly one record.
+     *
+     * @param results the result set
+     * @param clazz the queried class
+     * @param criteria the query criteria
+     * @return the single result, or {@code null} if empty
+     * @throws DuplicateEntryException if more than one result exists
+     */
+    private <R extends Record> R unique(Set<R> results, Class<R> clazz,
+            Criteria criteria) {
+        if(results.isEmpty()) {
+            return null;
+        }
+        else if(results.size() == 1) {
+            return results.iterator().next();
+        }
+        else {
+            throw new DuplicateEntryException(
+                    new com.cinchapi.concourse.thrift.DuplicateEntryException(
+                            "Multiple records match " + criteria + " in "
+                                    + clazz));
+        }
+    }
+
+}
+

--- a/src/main/java/com/cinchapi/runway/AdHocRecord.java
+++ b/src/main/java/com/cinchapi/runway/AdHocRecord.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2013-2025 Cinchapi Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cinchapi.runway;
+
+import java.util.function.Supplier;
+
+/**
+ * A read-only {@link Record} that is not persisted to the database.
+ * <p>
+ * An {@link AdHocRecord} is intended for temporary, non-persistent data
+ * structures that need to be compatible with the framework's data access
+ * patterns. This is useful for generating report-like structures, aggregated
+ * data views, or other read-only data representations.
+ * </p>
+ * <p>
+ * Subclasses define their schema through fields, just like regular
+ * {@link Record Records}. However, attempts to persist or modify an
+ * {@link AdHocRecord} will fail.
+ * </p>
+ * <p>
+ * {@link AdHocRecord AdHocRecords} are typically served through an
+ * {@link AdHocDatabase} and can be federated with a persistent data source via
+ * {@link FederatedRunway}.
+ * </p>
+ *
+ * @author Jeff Nelson
+ */
+public abstract class AdHocRecord extends Record {
+
+    /**
+     * A dummy field to work around a Runway static analysis limitation that
+     * requires at least one field to be defined.
+     */
+    @SuppressWarnings("unused")
+    private transient Object $$_$$;
+
+    @Override
+    public final void deleteOnSave() {
+        throw new UnsupportedOperationException(
+                "AdHocRecord cannot be deleted");
+    }
+
+    @Override
+    public final void set(String key, Object value) {
+        throw new UnsupportedOperationException("AdHocRecord is read-only");
+    }
+
+    @Override
+    protected final Supplier<Boolean> overrideSave() {
+        return () -> true;
+    }
+
+}

--- a/src/main/java/com/cinchapi/runway/FederatedRunway.java
+++ b/src/main/java/com/cinchapi/runway/FederatedRunway.java
@@ -1,0 +1,312 @@
+/*
+ * Copyright (c) 2013-2025 Cinchapi Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cinchapi.runway;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import com.cinchapi.concourse.lang.Criteria;
+import com.cinchapi.concourse.lang.paginate.Page;
+import com.cinchapi.concourse.lang.sort.Order;
+import com.google.common.base.Preconditions;
+
+/**
+ * A {@link DatabaseInterface} that unifies persistent data from {@link Runway}
+ * with ad-hoc data from {@link AdHocDatabase AdHocDatabases}.
+ * <p>
+ * A {@link FederatedRunway} routes queries to different data sources based on
+ * the requested class. Queries for registered {@link AdHocRecord} types are
+ * handled by their corresponding {@link AdHocDatabase}. All other queries are
+ * routed to the underlying {@link Runway} instance.
+ * </p>
+ * <h2>Example</h2>
+ * <pre>
+ * {@code
+ * AdHocDatabase<ReportRecord> reports = new AdHocDatabase<>(
+ *     ReportRecord.class, () -> generateReports());
+ *
+ * FederatedRunway db = FederatedRunway.builder()
+ *     .defaultTo(runway)
+ *     .register(reports)
+ *     .build();
+ *
+ * // Routes to runway
+ * db.load(User.class);
+ *
+ * // Routes to reports AdHocDatabase
+ * db.find(ReportRecord.class, criteria);
+ * }
+ * </pre>
+ *
+ * @author Jeff Nelson
+ */
+public final class FederatedRunway implements DatabaseInterface {
+
+    /**
+     * Return a new {@link Builder} for constructing a {@link FederatedRunway}.
+     *
+     * @return a new builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The default {@link Runway} for persistent record types.
+     */
+    private final Runway runway;
+
+    /**
+     * Mapping from class to the {@link AdHocDatabase} that handles it.
+     */
+    private final Map<Class<? extends AdHocRecord>, AdHocDatabase<?>> registry;
+
+    /**
+     * Construct a new instance.
+     *
+     * @param runway the default Runway
+     * @param registry the class-to-database mappings
+     */
+    private FederatedRunway(Runway runway,
+            Map<Class<? extends AdHocRecord>, AdHocDatabase<?>> registry) {
+        this.runway = runway;
+        this.registry = registry;
+    }
+
+    @Override
+    public <T extends Record> Set<T> find(Class<T> clazz, Criteria criteria,
+            Order order, Page page, Realms realms) {
+        return resolve(clazz).find(clazz, criteria, order, page, realms);
+    }
+
+    @Override
+    public <T extends Record> Set<T> find(Class<T> clazz, Criteria criteria,
+            Order order, Realms realms) {
+        return resolve(clazz).find(clazz, criteria, order, realms);
+    }
+
+    @Override
+    public <T extends Record> Set<T> find(Class<T> clazz, Criteria criteria,
+            Page page, Realms realms) {
+        return resolve(clazz).find(clazz, criteria, page, realms);
+    }
+
+    @Override
+    public <T extends Record> Set<T> find(Class<T> clazz, Criteria criteria,
+            Realms realms) {
+        return resolve(clazz).find(clazz, criteria, realms);
+    }
+
+    @Override
+    public <T extends Record> Set<T> findAny(Class<T> clazz, Criteria criteria,
+            Order order, Page page, Realms realms) {
+        return resolveHierarchy(clazz).findAny(clazz, criteria, order, page,
+                realms);
+    }
+
+    @Override
+    public <T extends Record> Set<T> findAny(Class<T> clazz, Criteria criteria,
+            Order order, Realms realms) {
+        return resolveHierarchy(clazz).findAny(clazz, criteria, order, realms);
+    }
+
+    @Override
+    public <T extends Record> Set<T> findAny(Class<T> clazz, Criteria criteria,
+            Page page, Realms realms) {
+        return resolveHierarchy(clazz).findAny(clazz, criteria, page, realms);
+    }
+
+    @Override
+    public <T extends Record> Set<T> findAny(Class<T> clazz, Criteria criteria,
+            Realms realms) {
+        return resolveHierarchy(clazz).findAny(clazz, criteria, realms);
+    }
+
+    @Override
+    public <T extends Record> T findAnyUnique(Class<T> clazz, Criteria criteria,
+            Realms realms) {
+        return resolveHierarchy(clazz).findAnyUnique(clazz, criteria, realms);
+    }
+
+    @Override
+    public <T extends Record> T findUnique(Class<T> clazz, Criteria criteria,
+            Realms realms) {
+        return resolve(clazz).findUnique(clazz, criteria, realms);
+    }
+
+    @Override
+    public <T extends Record> T load(Class<T> clazz, long id, Realms realms) {
+        return resolve(clazz).load(clazz, id, realms);
+    }
+
+    @Override
+    public <T extends Record> Set<T> load(Class<T> clazz, Order order,
+            Page page, Realms realms) {
+        return resolve(clazz).load(clazz, order, page, realms);
+    }
+
+    @Override
+    public <T extends Record> Set<T> load(Class<T> clazz, Order order,
+            Realms realms) {
+        return resolve(clazz).load(clazz, order, realms);
+    }
+
+    @Override
+    public <T extends Record> Set<T> load(Class<T> clazz, Page page,
+            Realms realms) {
+        return resolve(clazz).load(clazz, page, realms);
+    }
+
+    @Override
+    public <T extends Record> Set<T> load(Class<T> clazz, Realms realms) {
+        return resolve(clazz).load(clazz, realms);
+    }
+
+    @Override
+    public <T extends Record> Set<T> loadAny(Class<T> clazz, Order order,
+            Page page, Realms realms) {
+        return resolveHierarchy(clazz).loadAny(clazz, order, page, realms);
+    }
+
+    @Override
+    public <T extends Record> Set<T> loadAny(Class<T> clazz, Order order,
+            Realms realms) {
+        return resolveHierarchy(clazz).loadAny(clazz, order, realms);
+    }
+
+    @Override
+    public <T extends Record> Set<T> loadAny(Class<T> clazz, Page page,
+            Realms realms) {
+        return resolveHierarchy(clazz).loadAny(clazz, page, realms);
+    }
+
+    @Override
+    public <T extends Record> Set<T> loadAny(Class<T> clazz, Realms realms) {
+        return resolveHierarchy(clazz).loadAny(clazz, realms);
+    }
+
+    /**
+     * Resolve the {@link DatabaseInterface} for the given class.
+     * <p>
+     * Return the registered {@link AdHocDatabase} if the class is explicitly
+     * registered, otherwise return the default {@link Runway}.
+     * </p>
+     *
+     * @param clazz the class being queried
+     * @return the appropriate database
+     */
+    private DatabaseInterface resolve(Class<? extends Record> clazz) {
+        AdHocDatabase<?> db = registry.get(clazz);
+        return db != null ? db : runway;
+    }
+
+    /**
+     * Resolve the {@link DatabaseInterface} for hierarchy queries.
+     * <p>
+     * Check if any registered class is assignable from the requested class.
+     * If so, return that database; otherwise return the default
+     * {@link Runway}.
+     * </p>
+     *
+     * @param clazz the class being queried
+     * @return the appropriate database
+     */
+    private DatabaseInterface resolveHierarchy(Class<? extends Record> clazz) {
+        // First try exact match
+        AdHocDatabase<?> db = registry.get(clazz);
+        if(db != null) {
+            return db;
+        }
+        // Then check if any registered class is a subtype of the requested
+        // class
+        for (Map.Entry<Class<? extends AdHocRecord>, AdHocDatabase<?>> entry
+                : registry.entrySet()) {
+            if(clazz.isAssignableFrom(entry.getKey())) {
+                return entry.getValue();
+            }
+        }
+        return runway;
+    }
+
+    /**
+     * A builder for constructing {@link FederatedRunway} instances.
+     *
+     * @author Jeff Nelson
+     */
+    public static final class Builder {
+
+        /**
+         * The default Runway.
+         */
+        private Runway runway;
+
+        /**
+         * The class-to-database mappings.
+         */
+        private final Map<Class<? extends AdHocRecord>, AdHocDatabase<?>> registry;
+
+        /**
+         * Construct a new instance.
+         */
+        private Builder() {
+            this.registry = new LinkedHashMap<>();
+        }
+
+        /**
+         * Build and return the configured {@link FederatedRunway}.
+         *
+         * @return the federated runway
+         * @throws IllegalStateException if no default Runway is set
+         */
+        public FederatedRunway build() {
+            Preconditions.checkState(runway != null,
+                    "A default Runway must be set");
+            return new FederatedRunway(runway, registry);
+        }
+
+        /**
+         * Set the default {@link Runway} for persistent record types.
+         *
+         * @param runway the default Runway
+         * @return this builder
+         */
+        public Builder defaultTo(Runway runway) {
+            this.runway = runway;
+            return this;
+        }
+
+        /**
+         * Register an {@link AdHocDatabase} to handle queries for its
+         * registered class.
+         * <p>
+         * Queries for the database's registered class will be routed to it.
+         * For hierarchy queries (e.g., {@code loadAny}), queries for any
+         * supertype of the registered class will also be routed to this
+         * database.
+         * </p>
+         *
+         * @param db the ad-hoc database to register
+         * @return this builder
+         */
+        public Builder register(AdHocDatabase<?> db) {
+            this.registry.put(db.registeredClass(), db);
+            return this;
+        }
+    }
+
+}
+

--- a/src/test/java/com/cinchapi/runway/AdHocDatabaseTest.java
+++ b/src/test/java/com/cinchapi/runway/AdHocDatabaseTest.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) 2013-2025 Cinchapi Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cinchapi.runway;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.cinchapi.concourse.DuplicateEntryException;
+import com.cinchapi.concourse.lang.Criteria;
+import com.cinchapi.concourse.lang.paginate.Page;
+import com.cinchapi.concourse.lang.sort.Order;
+import com.cinchapi.concourse.thrift.Operator;
+
+/**
+ * Unit tests for {@link AdHocDatabase}.
+ *
+ * @author Jeff Nelson
+ */
+public class AdHocDatabaseTest {
+
+    @Test
+    public void testLoadAllRecords() {
+        Collection<MockAdHocRecord> data = Arrays.asList(
+                new MockAdHocRecord("Alice", 30),
+                new MockAdHocRecord("Bob", 25),
+                new MockAdHocRecord("Charlie", 35));
+        AdHocDatabase<MockAdHocRecord> db = new AdHocDatabase<>(
+                MockAdHocRecord.class, () -> data);
+
+        Set<MockAdHocRecord> results = db.load(MockAdHocRecord.class);
+
+        Assert.assertEquals(3, results.size());
+    }
+
+    @Test
+    public void testLoadById() {
+        MockAdHocRecord alice = new MockAdHocRecord("Alice", 30);
+        MockAdHocRecord bob = new MockAdHocRecord("Bob", 25);
+        Collection<MockAdHocRecord> data = Arrays.asList(alice, bob);
+        AdHocDatabase<MockAdHocRecord> db = new AdHocDatabase<>(
+                MockAdHocRecord.class, () -> data);
+
+        MockAdHocRecord result = db.load(MockAdHocRecord.class, alice.id());
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals("Alice", result.name);
+    }
+
+    @Test
+    public void testLoadByIdNotFound() {
+        Collection<MockAdHocRecord> data = Arrays
+                .asList(new MockAdHocRecord("Alice", 30));
+        AdHocDatabase<MockAdHocRecord> db = new AdHocDatabase<>(
+                MockAdHocRecord.class, () -> data);
+
+        MockAdHocRecord result = db.load(MockAdHocRecord.class, 99999L);
+
+        Assert.assertNull(result);
+    }
+
+    @Test
+    public void testFindWithCriteria() {
+        Collection<MockAdHocRecord> data = Arrays.asList(
+                new MockAdHocRecord("Alice", 30),
+                new MockAdHocRecord("Bob", 25),
+                new MockAdHocRecord("Charlie", 35));
+        AdHocDatabase<MockAdHocRecord> db = new AdHocDatabase<>(
+                MockAdHocRecord.class, () -> data);
+
+        Criteria criteria = Criteria.where().key("age")
+                .operator(Operator.GREATER_THAN).value(28).build();
+        Set<MockAdHocRecord> results = db.find(MockAdHocRecord.class, criteria);
+
+        Assert.assertEquals(2, results.size());
+    }
+
+    @Test
+    public void testFindWithOrder() {
+        Collection<MockAdHocRecord> data = Arrays.asList(
+                new MockAdHocRecord("Alice", 30),
+                new MockAdHocRecord("Bob", 25),
+                new MockAdHocRecord("Charlie", 35));
+        AdHocDatabase<MockAdHocRecord> db = new AdHocDatabase<>(
+                MockAdHocRecord.class, () -> data);
+
+        Criteria criteria = Criteria.where().key("age")
+                .operator(Operator.GREATER_THAN).value(0).build();
+        Order order = Order.by("age").ascending();
+        Set<MockAdHocRecord> results = db.find(MockAdHocRecord.class, criteria,
+                order);
+
+        MockAdHocRecord[] arr = results.toArray(new MockAdHocRecord[0]);
+        Assert.assertEquals("Bob", arr[0].name);
+        Assert.assertEquals("Alice", arr[1].name);
+        Assert.assertEquals("Charlie", arr[2].name);
+    }
+
+    @Test
+    public void testFindWithPagination() {
+        Collection<MockAdHocRecord> data = Arrays.asList(
+                new MockAdHocRecord("Alice", 30),
+                new MockAdHocRecord("Bob", 25),
+                new MockAdHocRecord("Charlie", 35),
+                new MockAdHocRecord("Diana", 28));
+        AdHocDatabase<MockAdHocRecord> db = new AdHocDatabase<>(
+                MockAdHocRecord.class, () -> data);
+
+        Criteria criteria = Criteria.where().key("age")
+                .operator(Operator.GREATER_THAN).value(0).build();
+        Page page = Page.sized(2);
+        Set<MockAdHocRecord> results = db.find(MockAdHocRecord.class, criteria,
+                page);
+
+        Assert.assertEquals(2, results.size());
+    }
+
+    @Test
+    public void testFindUnique() {
+        Collection<MockAdHocRecord> data = Arrays.asList(
+                new MockAdHocRecord("Alice", 30),
+                new MockAdHocRecord("Bob", 25));
+        AdHocDatabase<MockAdHocRecord> db = new AdHocDatabase<>(
+                MockAdHocRecord.class, () -> data);
+
+        Criteria criteria = Criteria.where().key("name")
+                .operator(Operator.EQUALS).value("Alice").build();
+        MockAdHocRecord result = db.findUnique(MockAdHocRecord.class, criteria);
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals("Alice", result.name);
+    }
+
+    @Test
+    public void testFindUniqueNotFound() {
+        Collection<MockAdHocRecord> data = Arrays
+                .asList(new MockAdHocRecord("Alice", 30));
+        AdHocDatabase<MockAdHocRecord> db = new AdHocDatabase<>(
+                MockAdHocRecord.class, () -> data);
+
+        Criteria criteria = Criteria.where().key("name")
+                .operator(Operator.EQUALS).value("Bob").build();
+        MockAdHocRecord result = db.findUnique(MockAdHocRecord.class, criteria);
+
+        Assert.assertNull(result);
+    }
+
+    @Test(expected = DuplicateEntryException.class)
+    public void testFindUniqueThrowsOnDuplicate() {
+        Collection<MockAdHocRecord> data = Arrays.asList(
+                new MockAdHocRecord("Alice", 30),
+                new MockAdHocRecord("Alice", 25));
+        AdHocDatabase<MockAdHocRecord> db = new AdHocDatabase<>(
+                MockAdHocRecord.class, () -> data);
+
+        Criteria criteria = Criteria.where().key("name")
+                .operator(Operator.EQUALS).value("Alice").build();
+        db.findUnique(MockAdHocRecord.class, criteria);
+    }
+
+    @Test
+    public void testUnregisteredClassReturnsEmpty() {
+        Collection<MockAdHocRecord> data = Arrays
+                .asList(new MockAdHocRecord("Alice", 30));
+        AdHocDatabase<MockAdHocRecord> db = new AdHocDatabase<>(
+                MockAdHocRecord.class, () -> data);
+
+        Set<OtherAdHocRecord> results = db.load(OtherAdHocRecord.class);
+
+        Assert.assertTrue(results.isEmpty());
+    }
+
+    @Test
+    public void testLoadAnyWithSuperclass() {
+        Collection<MockAdHocRecord> data = Arrays.asList(
+                new MockAdHocRecord("Alice", 30),
+                new MockAdHocRecord("Bob", 25));
+        AdHocDatabase<MockAdHocRecord> db = new AdHocDatabase<>(
+                MockAdHocRecord.class, () -> data);
+
+        Set<AdHocRecord> results = db.loadAny(AdHocRecord.class);
+
+        Assert.assertEquals(2, results.size());
+    }
+
+    @Test
+    public void testSupplierIsEvaluatedOnEachQuery() {
+        AtomicInteger counter = new AtomicInteger(0);
+        AdHocDatabase<MockAdHocRecord> db = new AdHocDatabase<>(
+                MockAdHocRecord.class, () -> {
+                    counter.incrementAndGet();
+                    return Arrays.asList(new MockAdHocRecord("Alice", 30));
+                });
+
+        db.load(MockAdHocRecord.class);
+        db.load(MockAdHocRecord.class);
+        db.load(MockAdHocRecord.class);
+
+        Assert.assertEquals(3, counter.get());
+    }
+
+    @Test
+    public void testCount() {
+        Collection<MockAdHocRecord> data = Arrays.asList(
+                new MockAdHocRecord("Alice", 30),
+                new MockAdHocRecord("Bob", 25),
+                new MockAdHocRecord("Charlie", 35));
+        AdHocDatabase<MockAdHocRecord> db = new AdHocDatabase<>(
+                MockAdHocRecord.class, () -> data);
+
+        int count = db.count(MockAdHocRecord.class);
+
+        Assert.assertEquals(3, count);
+    }
+
+    @Test
+    public void testCountWithCriteria() {
+        Collection<MockAdHocRecord> data = Arrays.asList(
+                new MockAdHocRecord("Alice", 30),
+                new MockAdHocRecord("Bob", 25),
+                new MockAdHocRecord("Charlie", 35));
+        AdHocDatabase<MockAdHocRecord> db = new AdHocDatabase<>(
+                MockAdHocRecord.class, () -> data);
+
+        Criteria criteria = Criteria.where().key("age")
+                .operator(Operator.GREATER_THAN).value(28).build();
+        int count = db.count(MockAdHocRecord.class, criteria);
+
+        Assert.assertEquals(2, count);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testAdHocRecordCannotBeDeleted() {
+        MockAdHocRecord record = new MockAdHocRecord("Alice", 30);
+        record.deleteOnSave();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testAdHocRecordCannotBeModified() {
+        MockAdHocRecord record = new MockAdHocRecord("Alice", 30);
+        record.set("name", "Bob");
+    }
+
+    /**
+     * A mock {@link AdHocRecord} for testing.
+     */
+    static class MockAdHocRecord extends AdHocRecord {
+
+        String name;
+        int age;
+
+        MockAdHocRecord(String name, int age) {
+            this.name = name;
+            this.age = age;
+        }
+    }
+
+    /**
+     * Another mock {@link AdHocRecord} for testing unregistered class behavior.
+     */
+    static class OtherAdHocRecord extends AdHocRecord {
+
+        String value;
+    }
+
+}

--- a/src/test/java/com/cinchapi/runway/AdHocRecordCompositionTest.java
+++ b/src/test/java/com/cinchapi/runway/AdHocRecordCompositionTest.java
@@ -1,0 +1,571 @@
+/*
+ * Copyright (c) 2013-2025 Cinchapi Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cinchapi.runway;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import javax.annotation.Nonnull;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.cinchapi.concourse.lang.Criteria;
+import com.cinchapi.concourse.thrift.Operator;
+import com.cinchapi.runway.access.AccessControl;
+import com.cinchapi.runway.access.Audience;
+import com.cinchapi.runway.access.RestrictedAccessException;
+import com.google.common.collect.ImmutableSet;
+
+/**
+ * Unit tests verifying that {@link AdHocRecord AdHocRecords} can properly
+ * compose with framework interfaces such as {@link Audience} and
+ * {@link AccessControl}.
+ *
+ * @author Jeff Nelson
+ */
+public class AdHocRecordCompositionTest {
+
+    // ========================================================================
+    // Audience Tests
+    // ========================================================================
+
+    @Test
+    public void testAdHocRecordAsAudienceVisibilityFilter() {
+        AudienceAdHocRecord adminViewer = new AudienceAdHocRecord("Admin",
+                "admin");
+        AudienceAdHocRecord guestViewer = new AudienceAdHocRecord("Guest",
+                "guest");
+
+        AccessControlledAdHocRecord publicDoc = new AccessControlledAdHocRecord(
+                "PublicDoc", true, true);
+        AccessControlledAdHocRecord privateDoc = new AccessControlledAdHocRecord(
+                "PrivateDoc", false, true);
+
+        AdHocDatabase<AccessControlledAdHocRecord> db = new AdHocDatabase<>(
+                AccessControlledAdHocRecord.class,
+                () -> Arrays.asList(publicDoc, privateDoc));
+
+        // Admin should see both documents
+        Predicate<AccessControlledAdHocRecord> adminFilter = adminViewer
+                .$checkIfVisible();
+        Set<AccessControlledAdHocRecord> adminResults = db.load(
+                AccessControlledAdHocRecord.class, adminFilter);
+        Assert.assertEquals(2, adminResults.size());
+
+        // Guest should only see public document
+        Predicate<AccessControlledAdHocRecord> guestFilter = guestViewer
+                .$checkIfVisible();
+        Set<AccessControlledAdHocRecord> guestResults = db.load(
+                AccessControlledAdHocRecord.class, guestFilter);
+        Assert.assertEquals(1, guestResults.size());
+        Assert.assertEquals("PublicDoc",
+                guestResults.iterator().next().title);
+    }
+
+    @Test
+    public void testAdHocRecordAsAudienceFilterWithCriteria() {
+        AudienceAdHocRecord viewer = new AudienceAdHocRecord("Viewer", "guest");
+
+        AccessControlledAdHocRecord doc1 = new AccessControlledAdHocRecord(
+                "Alpha", true, true);
+        AccessControlledAdHocRecord doc2 = new AccessControlledAdHocRecord(
+                "Beta", true, false);
+        AccessControlledAdHocRecord doc3 = new AccessControlledAdHocRecord(
+                "Gamma", false, true);
+
+        AdHocDatabase<AccessControlledAdHocRecord> db = new AdHocDatabase<>(
+                AccessControlledAdHocRecord.class,
+                () -> Arrays.asList(doc1, doc2, doc3));
+
+        Criteria criteria = Criteria.where().key("active")
+                .operator(Operator.EQUALS).value(true).build();
+
+        // Viewer (guest) with criteria should only see doc1 (public and active)
+        Predicate<AccessControlledAdHocRecord> filter = viewer
+                .$checkIfVisible();
+        Set<AccessControlledAdHocRecord> results = db.find(
+                AccessControlledAdHocRecord.class, criteria, filter);
+        Assert.assertEquals(1, results.size());
+        Assert.assertEquals("Alpha", results.iterator().next().title);
+    }
+
+    // ========================================================================
+    // AccessControl Tests
+    // ========================================================================
+
+    @Test
+    public void testAccessControlledAdHocRecordReadableBy() {
+        AudienceAdHocRecord admin = new AudienceAdHocRecord("Admin", "admin");
+        AudienceAdHocRecord guest = new AudienceAdHocRecord("Guest", "guest");
+
+        AccessControlledAdHocRecord doc = new AccessControlledAdHocRecord(
+                "Secret", false, true);
+
+        // Admin should be able to read all keys
+        Set<String> adminReadable = doc.$readableBy(admin);
+        Assert.assertEquals(AccessControl.ALL_KEYS, adminReadable);
+
+        // Guest should not be able to read any keys for private doc
+        Set<String> guestReadable = doc.$readableBy(guest);
+        Assert.assertEquals(AccessControl.NO_KEYS, guestReadable);
+    }
+
+    @Test
+    public void testAccessControlledAdHocRecordDiscoverability() {
+        AudienceAdHocRecord admin = new AudienceAdHocRecord("Admin", "admin");
+        AudienceAdHocRecord guest = new AudienceAdHocRecord("Guest", "guest");
+
+        AccessControlledAdHocRecord publicDoc = new AccessControlledAdHocRecord(
+                "Public", true, true);
+        AccessControlledAdHocRecord privateDoc = new AccessControlledAdHocRecord(
+                "Private", false, true);
+
+        // Admin discovers all
+        Assert.assertTrue(publicDoc.$isDiscoverableBy(admin));
+        Assert.assertTrue(privateDoc.$isDiscoverableBy(admin));
+
+        // Guest only discovers public
+        Assert.assertTrue(publicDoc.$isDiscoverableBy(guest));
+        Assert.assertFalse(privateDoc.$isDiscoverableBy(guest));
+    }
+
+    @Test
+    public void testAccessControlledAdHocRecordFrameAs() {
+        AudienceAdHocRecord admin = new AudienceAdHocRecord("Admin", "admin");
+        AudienceAdHocRecord guest = new AudienceAdHocRecord("Guest", "guest");
+
+        FieldLevelAccessAdHocRecord doc = new FieldLevelAccessAdHocRecord(
+                "Document", "public summary", "confidential details");
+
+        // Admin should see all fields
+        Map<String, Object> adminFrame = doc.frameAs(admin);
+        Assert.assertNotNull(adminFrame);
+        Assert.assertTrue(adminFrame.containsKey("title"));
+        Assert.assertTrue(adminFrame.containsKey("summary"));
+        Assert.assertTrue(adminFrame.containsKey("confidential"));
+
+        // Guest should only see title and summary
+        Map<String, Object> guestFrame = doc.frameAs(guest);
+        Assert.assertNotNull(guestFrame);
+        Assert.assertTrue(guestFrame.containsKey("title"));
+        Assert.assertTrue(guestFrame.containsKey("summary"));
+        Assert.assertFalse(guestFrame.containsKey("confidential"));
+    }
+
+    @Test
+    public void testAccessControlledAdHocRecordReadAsReturnsNullWhenRestricted() {
+        AudienceAdHocRecord guest = new AudienceAdHocRecord("Guest", "guest");
+
+        FieldLevelAccessAdHocRecord doc = new FieldLevelAccessAdHocRecord(
+                "Document", "summary", "secret");
+
+        // Guest trying to read confidential field should get null
+        // (the single-key readAs filters data, the Collection-based read throws)
+        Object result = doc.readAs(guest, "confidential");
+        Assert.assertNull(result);
+    }
+
+    @Test(expected = RestrictedAccessException.class)
+    public void testAccessControlledAdHocRecordReadCollectionThrowsWhenRestricted() {
+        AudienceAdHocRecord guest = new AudienceAdHocRecord("Guest", "guest");
+
+        FieldLevelAccessAdHocRecord doc = new FieldLevelAccessAdHocRecord(
+                "Document", "summary", "secret");
+
+        // Using Collection-based read should throw when accessing restricted key
+        guest.read(ImmutableSet.of("confidential"), doc);
+    }
+
+    @Test
+    public void testAccessControlledAdHocRecordAnonymousDiscoverability() {
+        AccessControlledAdHocRecord publicDoc = new AccessControlledAdHocRecord(
+                "Public", true, true);
+        AccessControlledAdHocRecord privateDoc = new AccessControlledAdHocRecord(
+                "Private", false, true);
+
+        Assert.assertTrue(publicDoc.$isDiscoverableByAnonymous());
+        Assert.assertFalse(privateDoc.$isDiscoverableByAnonymous());
+    }
+
+    @Test
+    public void testAudienceAnonymousFilter() {
+        AccessControlledAdHocRecord publicDoc = new AccessControlledAdHocRecord(
+                "Public", true, true);
+        AccessControlledAdHocRecord privateDoc = new AccessControlledAdHocRecord(
+                "Private", false, true);
+
+        AdHocDatabase<AccessControlledAdHocRecord> db = new AdHocDatabase<>(
+                AccessControlledAdHocRecord.class,
+                () -> Arrays.asList(publicDoc, privateDoc));
+
+        // Anonymous audience should only see public documents
+        Audience anonymous = Audience.anonymous();
+        Predicate<AccessControlledAdHocRecord> filter = anonymous
+                .$checkIfVisible();
+        Set<AccessControlledAdHocRecord> results = db.load(
+                AccessControlledAdHocRecord.class, filter);
+        Assert.assertEquals(1, results.size());
+        Assert.assertEquals("Public", results.iterator().next().title);
+    }
+
+    // ========================================================================
+    // Combined Audience + AccessControl Tests
+    // ========================================================================
+
+    @Test
+    public void testAdHocRecordImplementsBothAudienceAndAccessControl() {
+        DualRoleAdHocRecord user1 = new DualRoleAdHocRecord("Alice", "admin");
+        DualRoleAdHocRecord user2 = new DualRoleAdHocRecord("Bob", "viewer");
+
+        AdHocDatabase<DualRoleAdHocRecord> db = new AdHocDatabase<>(
+                DualRoleAdHocRecord.class, () -> Arrays.asList(user1, user2));
+
+        // user1 (admin) should see both users
+        Predicate<DualRoleAdHocRecord> adminFilter = user1.$checkIfVisible();
+        Set<DualRoleAdHocRecord> adminResults = db.load(
+                DualRoleAdHocRecord.class, adminFilter);
+        Assert.assertEquals(2, adminResults.size());
+
+        // user2 (viewer) should only see themselves
+        Predicate<DualRoleAdHocRecord> viewerFilter = user2.$checkIfVisible();
+        Set<DualRoleAdHocRecord> viewerResults = db.load(
+                DualRoleAdHocRecord.class, viewerFilter);
+        Assert.assertEquals(1, viewerResults.size());
+        Assert.assertEquals("Bob", viewerResults.iterator().next().name);
+    }
+
+    @Test
+    public void testVisibilityFilterWithFindAndCriteria() {
+        AudienceAdHocRecord viewer = new AudienceAdHocRecord("Viewer", "guest");
+
+        AccessControlledAdHocRecord doc1 = new AccessControlledAdHocRecord(
+                "Public1", true, true);
+        AccessControlledAdHocRecord doc2 = new AccessControlledAdHocRecord(
+                "Private1", false, true);
+        AccessControlledAdHocRecord doc3 = new AccessControlledAdHocRecord(
+                "Public2", true, false);
+
+        AdHocDatabase<AccessControlledAdHocRecord> db = new AdHocDatabase<>(
+                AccessControlledAdHocRecord.class,
+                () -> Arrays.asList(doc1, doc2, doc3));
+
+        // Guest viewer with filter should only see public documents
+        Predicate<AccessControlledAdHocRecord> filter = viewer
+                .$checkIfVisible();
+        Set<AccessControlledAdHocRecord> results = db.load(
+                AccessControlledAdHocRecord.class, filter);
+        Assert.assertEquals(2, results.size());
+
+        // With additional criteria for active only
+        Criteria activeCriteria = Criteria.where().key("active")
+                .operator(Operator.EQUALS).value(true).build();
+        Set<AccessControlledAdHocRecord> activeResults = db.find(
+                AccessControlledAdHocRecord.class, activeCriteria, filter);
+        Assert.assertEquals(1, activeResults.size());
+        Assert.assertEquals("Public1", activeResults.iterator().next().title);
+    }
+
+    @Test
+    public void testAdHocRecordCheckIfVisibleReturnsPredicateThatFilters() {
+        AudienceAdHocRecord admin = new AudienceAdHocRecord("Admin", "admin");
+        AudienceAdHocRecord guest = new AudienceAdHocRecord("Guest", "guest");
+
+        AccessControlledAdHocRecord publicDoc = new AccessControlledAdHocRecord(
+                "Public", true, true);
+        AccessControlledAdHocRecord privateDoc = new AccessControlledAdHocRecord(
+                "Private", false, true);
+
+        // Verify predicate behavior directly
+        Predicate<AccessControlledAdHocRecord> adminPredicate = admin
+                .$checkIfVisible();
+        Predicate<AccessControlledAdHocRecord> guestPredicate = guest
+                .$checkIfVisible();
+
+        Assert.assertTrue(adminPredicate.test(publicDoc));
+        Assert.assertTrue(adminPredicate.test(privateDoc));
+        Assert.assertTrue(guestPredicate.test(publicDoc));
+        Assert.assertFalse(guestPredicate.test(privateDoc));
+    }
+
+    @Test
+    public void testAdHocRecordAccessControlWithSelfDiscovery() {
+        // An Audience always has access to itself
+        DualRoleAdHocRecord user = new DualRoleAdHocRecord("Alice", "viewer");
+
+        Predicate<DualRoleAdHocRecord> filter = user.$checkIfVisible();
+
+        // User should always be able to see themselves
+        Assert.assertTrue(filter.test(user));
+    }
+
+    // ========================================================================
+    // Test Record Classes
+    // ========================================================================
+
+    /**
+     * An {@link AdHocRecord} that implements {@link Audience}.
+     */
+    static class AudienceAdHocRecord extends AdHocRecord implements Audience {
+
+        String name;
+        String role;
+
+        AudienceAdHocRecord(String name, String role) {
+            this.name = name;
+            this.role = role;
+        }
+
+        @Override
+        public DatabaseInterface $db() {
+            // Return null since we don't have a real DB connection
+            // This is OK for testing $checkIfVisible() which doesn't need $db()
+            return null;
+        }
+    }
+
+    /**
+     * An {@link AdHocRecord} that implements {@link AccessControl}.
+     */
+    static class AccessControlledAdHocRecord extends AdHocRecord
+            implements AccessControl {
+
+        String title;
+        boolean isPublic;
+        boolean active;
+
+        AccessControlledAdHocRecord(String title, boolean isPublic,
+                boolean active) {
+            this.title = title;
+            this.isPublic = isPublic;
+            this.active = active;
+        }
+
+        @Override
+        public boolean $isCreatableBy(@Nonnull Audience audience) {
+            return isAdmin(audience);
+        }
+
+        @Override
+        public boolean $isCreatableByAnonymous() {
+            return false;
+        }
+
+        @Override
+        public boolean $isDeletableBy(@Nonnull Audience audience) {
+            return isAdmin(audience);
+        }
+
+        @Override
+        public boolean $isDiscoverableBy(@Nonnull Audience audience) {
+            return isPublic || isAdmin(audience);
+        }
+
+        @Override
+        public boolean $isDiscoverableByAnonymous() {
+            return isPublic;
+        }
+
+        @Override
+        public Set<String> $readableBy(@Nonnull Audience audience) {
+            if(isAdmin(audience) || isPublic) {
+                return ALL_KEYS;
+            }
+            return NO_KEYS;
+        }
+
+        @Override
+        public Set<String> $readableByAnonymous() {
+            return isPublic ? ALL_KEYS : NO_KEYS;
+        }
+
+        @Override
+        public Set<String> $writableBy(@Nonnull Audience audience) {
+            return isAdmin(audience) ? ALL_KEYS : NO_KEYS;
+        }
+
+        @Override
+        public Set<String> $writableByAnonymous() {
+            return NO_KEYS;
+        }
+
+        private boolean isAdmin(Audience audience) {
+            if(audience instanceof AudienceAdHocRecord) {
+                return "admin".equals(((AudienceAdHocRecord) audience).role);
+            }
+            return false;
+        }
+    }
+
+    /**
+     * An {@link AdHocRecord} with field-level access control.
+     */
+    static class FieldLevelAccessAdHocRecord extends AdHocRecord
+            implements AccessControl {
+
+        String title;
+        String summary;
+        String confidential;
+
+        FieldLevelAccessAdHocRecord(String title, String summary,
+                String confidential) {
+            this.title = title;
+            this.summary = summary;
+            this.confidential = confidential;
+        }
+
+        @Override
+        public boolean $isCreatableBy(@Nonnull Audience audience) {
+            return true;
+        }
+
+        @Override
+        public boolean $isCreatableByAnonymous() {
+            return false;
+        }
+
+        @Override
+        public boolean $isDeletableBy(@Nonnull Audience audience) {
+            return isAdmin(audience);
+        }
+
+        @Override
+        public boolean $isDiscoverableBy(@Nonnull Audience audience) {
+            return true;
+        }
+
+        @Override
+        public boolean $isDiscoverableByAnonymous() {
+            return true;
+        }
+
+        @Override
+        public Set<String> $readableBy(@Nonnull Audience audience) {
+            if(isAdmin(audience)) {
+                return ALL_KEYS;
+            }
+            // Non-admins can only see title and summary
+            return ImmutableSet.of("title", "summary");
+        }
+
+        @Override
+        public Set<String> $readableByAnonymous() {
+            return ImmutableSet.of("title");
+        }
+
+        @Override
+        public Set<String> $writableBy(@Nonnull Audience audience) {
+            return isAdmin(audience) ? ALL_KEYS : NO_KEYS;
+        }
+
+        @Override
+        public Set<String> $writableByAnonymous() {
+            return NO_KEYS;
+        }
+
+        private boolean isAdmin(Audience audience) {
+            if(audience instanceof AudienceAdHocRecord) {
+                return "admin".equals(((AudienceAdHocRecord) audience).role);
+            }
+            return false;
+        }
+    }
+
+    /**
+     * An {@link AdHocRecord} that implements both {@link Audience} and
+     * {@link AccessControl}.
+     */
+    static class DualRoleAdHocRecord extends AdHocRecord
+            implements Audience, AccessControl {
+
+        String name;
+        String role;
+
+        DualRoleAdHocRecord(String name, String role) {
+            this.name = name;
+            this.role = role;
+        }
+
+        @Override
+        public DatabaseInterface $db() {
+            return null;
+        }
+
+        @Override
+        public boolean $isCreatableBy(@Nonnull Audience audience) {
+            return true;
+        }
+
+        @Override
+        public boolean $isCreatableByAnonymous() {
+            return false;
+        }
+
+        @Override
+        public boolean $isDeletableBy(@Nonnull Audience audience) {
+            return audience.equals(this) || isAdmin(audience);
+        }
+
+        @Override
+        public boolean $isDiscoverableBy(@Nonnull Audience audience) {
+            // Admins can see everyone, others can only see themselves
+            return isAdmin(audience) || audience.equals(this);
+        }
+
+        @Override
+        public boolean $isDiscoverableByAnonymous() {
+            return false;
+        }
+
+        @Override
+        public Set<String> $readableBy(@Nonnull Audience audience) {
+            // Only admins and self can read; others have no access
+            // This ensures $checkIfVisible() only passes for discoverable users
+            if(isAdmin(audience) || audience.equals(this)) {
+                return ALL_KEYS;
+            }
+            return NO_KEYS;
+        }
+
+        @Override
+        public Set<String> $readableByAnonymous() {
+            return NO_KEYS;
+        }
+
+        @Override
+        public Set<String> $writableBy(@Nonnull Audience audience) {
+            if(isAdmin(audience) || audience.equals(this)) {
+                return ALL_KEYS;
+            }
+            return NO_KEYS;
+        }
+
+        @Override
+        public Set<String> $writableByAnonymous() {
+            return NO_KEYS;
+        }
+
+        private boolean isAdmin(Audience audience) {
+            if(audience instanceof DualRoleAdHocRecord) {
+                return "admin".equals(((DualRoleAdHocRecord) audience).role);
+            }
+            return false;
+        }
+    }
+
+}

--- a/src/test/java/com/cinchapi/runway/FederatedRunwayTest.java
+++ b/src/test/java/com/cinchapi/runway/FederatedRunwayTest.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright (c) 2013-2025 Cinchapi Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cinchapi.runway;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.cinchapi.common.base.CheckedExceptions;
+import com.cinchapi.concourse.lang.Criteria;
+import com.cinchapi.concourse.test.ClientServerTest;
+import com.cinchapi.concourse.thrift.Operator;
+
+/**
+ * Unit tests for {@link FederatedRunway}.
+ *
+ * @author Jeff Nelson
+ */
+public class FederatedRunwayTest extends ClientServerTest {
+
+    private Runway runway;
+
+    @Override
+    protected String getServerVersion() {
+        return Testing.CONCOURSE_VERSION;
+    }
+
+    @Override
+    public void beforeEachTest() {
+        runway = Runway.builder().port(server.getClientPort()).build();
+    }
+
+    @Override
+    public void afterEachTest() {
+        try {
+            runway.close();
+        }
+        catch (Exception e) {
+            throw CheckedExceptions.throwAsRuntimeException(e);
+        }
+    }
+
+    @Test
+    public void testRoutesToDefaultForUnregisteredClass() {
+        MockRecord record = new MockRecord();
+        record.name = "Test";
+        runway.save(record);
+
+        FederatedRunway db = FederatedRunway.builder()
+                .defaultTo(runway)
+                .build();
+
+        Set<MockRecord> results = db.load(MockRecord.class);
+
+        Assert.assertEquals(1, results.size());
+    }
+
+    @Test
+    public void testRoutesToRegisteredAdHocDatabase() {
+        Collection<MockAdHocRecord> data = Arrays.asList(
+                new MockAdHocRecord("Alice", 30),
+                new MockAdHocRecord("Bob", 25));
+        AdHocDatabase<MockAdHocRecord> adhocDb = new AdHocDatabase<>(
+                MockAdHocRecord.class, () -> data);
+
+        FederatedRunway db = FederatedRunway.builder()
+                .defaultTo(runway)
+                .register(adhocDb)
+                .build();
+
+        Set<MockAdHocRecord> results = db.load(MockAdHocRecord.class);
+
+        Assert.assertEquals(2, results.size());
+    }
+
+    @Test
+    public void testFederatesMultipleAdHocDatabases() {
+        Collection<MockAdHocRecord> data1 = Arrays
+                .asList(new MockAdHocRecord("Alice", 30));
+        Collection<OtherAdHocRecord> data2 = Arrays
+                .asList(new OtherAdHocRecord("Value1"),
+                        new OtherAdHocRecord("Value2"));
+
+        AdHocDatabase<MockAdHocRecord> adhocDb1 = new AdHocDatabase<>(
+                MockAdHocRecord.class, () -> data1);
+        AdHocDatabase<OtherAdHocRecord> adhocDb2 = new AdHocDatabase<>(
+                OtherAdHocRecord.class, () -> data2);
+
+        FederatedRunway db = FederatedRunway.builder()
+                .defaultTo(runway)
+                .register(adhocDb1)
+                .register(adhocDb2)
+                .build();
+
+        Assert.assertEquals(1, db.load(MockAdHocRecord.class).size());
+        Assert.assertEquals(2, db.load(OtherAdHocRecord.class).size());
+    }
+
+    @Test
+    public void testFindRoutesToCorrectDatabase() {
+        Collection<MockAdHocRecord> data = Arrays.asList(
+                new MockAdHocRecord("Alice", 30),
+                new MockAdHocRecord("Bob", 25));
+        AdHocDatabase<MockAdHocRecord> adhocDb = new AdHocDatabase<>(
+                MockAdHocRecord.class, () -> data);
+
+        FederatedRunway db = FederatedRunway.builder()
+                .defaultTo(runway)
+                .register(adhocDb)
+                .build();
+
+        Criteria criteria = Criteria.where().key("age")
+                .operator(Operator.GREATER_THAN).value(26).build();
+        Set<MockAdHocRecord> results = db.find(MockAdHocRecord.class, criteria);
+
+        Assert.assertEquals(1, results.size());
+        Assert.assertEquals("Alice",
+                results.iterator().next().name);
+    }
+
+    @Test
+    public void testLoadAnyRoutesToAdHocDatabaseForSuperclass() {
+        Collection<MockAdHocRecord> data = Arrays.asList(
+                new MockAdHocRecord("Alice", 30),
+                new MockAdHocRecord("Bob", 25));
+        AdHocDatabase<MockAdHocRecord> adhocDb = new AdHocDatabase<>(
+                MockAdHocRecord.class, () -> data);
+
+        FederatedRunway db = FederatedRunway.builder()
+                .defaultTo(runway)
+                .register(adhocDb)
+                .build();
+
+        Set<AdHocRecord> results = db.loadAny(AdHocRecord.class);
+
+        Assert.assertEquals(2, results.size());
+    }
+
+    @Test
+    public void testPersistentAndAdHocCoexist() {
+        // Save persistent record
+        MockRecord persistent = new MockRecord();
+        persistent.name = "Persistent";
+        runway.save(persistent);
+
+        // Create ad-hoc data
+        Collection<MockAdHocRecord> adhocData = Arrays.asList(
+                new MockAdHocRecord("AdHoc1", 10),
+                new MockAdHocRecord("AdHoc2", 20));
+        AdHocDatabase<MockAdHocRecord> adhocDb = new AdHocDatabase<>(
+                MockAdHocRecord.class, () -> adhocData);
+
+        FederatedRunway db = FederatedRunway.builder()
+                .defaultTo(runway)
+                .register(adhocDb)
+                .build();
+
+        // Both work through same interface
+        Assert.assertEquals(1, db.load(MockRecord.class).size());
+        Assert.assertEquals(2, db.load(MockAdHocRecord.class).size());
+    }
+
+    @Test
+    public void testLoadByIdRoutesToCorrectDatabase() {
+        MockAdHocRecord alice = new MockAdHocRecord("Alice", 30);
+        Collection<MockAdHocRecord> data = Arrays.asList(alice);
+        AdHocDatabase<MockAdHocRecord> adhocDb = new AdHocDatabase<>(
+                MockAdHocRecord.class, () -> data);
+
+        FederatedRunway db = FederatedRunway.builder()
+                .defaultTo(runway)
+                .register(adhocDb)
+                .build();
+
+        MockAdHocRecord result = db.load(MockAdHocRecord.class, alice.id());
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals("Alice", result.name);
+    }
+
+    @Test
+    public void testCountRoutesToCorrectDatabase() {
+        Collection<MockAdHocRecord> data = Arrays.asList(
+                new MockAdHocRecord("Alice", 30),
+                new MockAdHocRecord("Bob", 25),
+                new MockAdHocRecord("Charlie", 35));
+        AdHocDatabase<MockAdHocRecord> adhocDb = new AdHocDatabase<>(
+                MockAdHocRecord.class, () -> data);
+
+        FederatedRunway db = FederatedRunway.builder()
+                .defaultTo(runway)
+                .register(adhocDb)
+                .build();
+
+        Assert.assertEquals(3, db.count(MockAdHocRecord.class));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testBuilderRequiresDefaultRunway() {
+        FederatedRunway.builder().build();
+    }
+
+    /**
+     * A persistent mock record for testing.
+     */
+    static class MockRecord extends Record {
+
+        String name;
+    }
+
+    /**
+     * A mock {@link AdHocRecord} for testing.
+     */
+    static class MockAdHocRecord extends AdHocRecord {
+
+        String name;
+        int age;
+
+        MockAdHocRecord(String name, int age) {
+            this.name = name;
+            this.age = age;
+        }
+    }
+
+    /**
+     * Another mock {@link AdHocRecord} for testing.
+     */
+    static class OtherAdHocRecord extends AdHocRecord {
+
+        String value;
+
+        OtherAdHocRecord(String value) {
+            this.value = value;
+        }
+    }
+
+}
+


### PR DESCRIPTION
Runway now provides infrastructure for serving non-persistent, in-mem…ory data through the standard `DatabaseInterface` API. This enables seamless integration of programmatic data sources with persistent database records.

* **`AdHocRecord`**: A read-only `Record` base class for temporary, non-persistent data structures. Subclasses define their schema through fields like regular Records, but attempts to persist or modify an `AdHocRecord` will throw an `UnsupportedOperationException`. This is useful for generating report-like structures, aggregated data views, or other read-only data representations that need to be compatible with the application's data access patterns.

* **`AdHocDatabase`**: A `DatabaseInterface` implementation that serves a single `AdHocRecord` type from an in-memory data source. Data is supplied via a `Supplier` that is evaluated on each query, allowing for dynamic or computed data. The `AdHocDatabase` supports full query capabilities including `Criteria` filtering, `Order` sorting, and `Page` pagination—all resolved in-memory against the supplied collection.

* **`FederatedRunway`**: A `DatabaseInterface` implementation that unifies persistent data from `Runway` with ad-hoc data from one or more `AdHocDatabase` instances. Queries are automatically routed to the appropriate data source based on the requested class. This enables applications to expose both persistent and programmatic data through a single, unified API. ```java AdHocDatabase<ReportRecord> reports = new AdHocDatabase<>( ReportRecord.class, () -> generateReports());

  FederatedRunway db = FederatedRunway.builder() .defaultTo(runway) .register(reports) .build();

  // Routes to Runway db.load(User.class); // Routes to AdHocDatabase db.find(ReportRecord.class, criteria); ```