### PR TITLE
GH-94: Fix InvalidArgumentException when loading nested dangling Links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 #### Version 1.15.0 (TBD)
 
+#### Version 1.14.6 (TBD)
+* Fixed a bug where loading a `Record` graph that contained a nested `Record` with a dangling `Link` (one whose target had been cleared) inside a `Collection<Record>` field would throw `InvalidArgumentException`, making the entire graph unloadable. Runway optimistically cleans up such dangling `Links` during load &mdash; removing them from storage so the load can proceed &mdash; but this cleanup previously only worked for the top-level `Record` being loaded and failed for any deeper `Record` in the graph. ([GH-94](https://github.com/cinchapi/runway/issues/94))
+
 #### Version 1.14.5 (April 14, 2026)
 * Fixed a bug where an anonymous audience could not discover access-controlled records that were readable or writable by anonymous unless discoverability was also explicitly granted, unlike non-anonymous audiences who could implicitly discover any record they were permitted to read or write
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 #### Version 1.15.0 (TBD)
 
 #### Version 1.14.6 (TBD)
-* Fixed a bug where loading a `Record` graph that contained a nested `Record` with a dangling `Link` (one whose target had been cleared) inside a `Collection<Record>` field would throw `InvalidArgumentException`, making the entire graph unloadable. Runway optimistically cleans up such dangling `Links` during load &mdash; removing them from storage so the load can proceed &mdash; but this cleanup previously only worked for the top-level `Record` being loaded and failed for any deeper `Record` in the graph. ([GH-94](https://github.com/cinchapi/runway/issues/94))
+* Fixed a bug where loading a `Record` graph that contained a nested `Record` with a dangling `Link` (one whose target had been cleared) would throw `InvalidArgumentException`, making the graph unloadable until the dangling `Link` was removed manually. ([GH-94](https://github.com/cinchapi/runway/issues/94))
 
 #### Version 1.14.5 (April 14, 2026)
 * Fixed a bug where an anonymous audience could not discover access-controlled records that were readable or writable by anonymous unless discoverability was also explicitly granted, unlike non-anonymous audiences who could implicitly discover any record they were permitted to read or write

--- a/src/main/java/com/cinchapi/runway/Record.java
+++ b/src/main/java/com/cinchapi/runway/Record.java
@@ -2141,8 +2141,8 @@ public abstract class Record implements Comparable<Record> {
                                         Object.class);
                         ArrayBuilder collector = ArrayBuilder.builder();
                         stored.forEach(item -> {
-                            Object converted = convert(path, collectedType,
-                                    item, concourse, existing, targets);
+                            Object converted = convert(key, collectedType, item,
+                                    concourse, existing, targets);
                             if(converted != null) {
                                 collector.add(converted);
                             }
@@ -2205,7 +2205,7 @@ public abstract class Record implements Comparable<Record> {
                             }
                         }
                         else if(first != null) {
-                            value = convert(path, type, first, concourse,
+                            value = convert(key, type, first, concourse,
                                     existing, targets);
                         }
                     }
@@ -2658,8 +2658,16 @@ public abstract class Record implements Comparable<Record> {
     /**
      * Convert the {@code stored} value for {@code key} into the appropriate
      * Java object based on the field {@code type}.
+     * <p>
+     * As ad-hoc cleanup, a dangling {@link Link} (one whose target
+     * {@link Record} no longer exists) is removed from {@code key} on
+     * {@code this} {@link Record} and {@code null} is returned.
      *
-     * @param key
+     * @param key the Concourse field name on {@code this} {@link Record} where
+     *            {@code stored} is held; must be the canonical field name
+     *            (e.g., {@code "pebbles"}), not a navigation path (e.g.,
+     *            {@code "stone.pebbles"}), so that dangling-link cleanup writes
+     *            against a valid Concourse key
      * @param type
      * @param stored
      * @param concourse

--- a/src/test/java/com/cinchapi/runway/GH94.java
+++ b/src/test/java/com/cinchapi/runway/GH94.java
@@ -107,6 +107,60 @@ public class GH94 extends RunwayBaseClientServerTest {
     }
 
     /**
+     * <strong>Goal:</strong> Verify that loading a {@link Boulder} whose
+     * deeply-nested {@link Stone#core} reference points to a dangling
+     * {@link Pebble} (a {@link Link} whose target has been cleared) does not
+     * throw {@code InvalidArgumentException} from the dangling-link cleanup
+     * logic at the scalar branch.
+     * <p>
+     * The {@link Stone#core} field is loaded under prefix {@code "stone."}, so
+     * the {@code convert(...)} call sees the navigation path
+     * {@code "stone.core"} (a Concourse-invalid key) instead of the canonical
+     * field name {@code "core"}, causing the cleanup of the dangling
+     * {@link Link} to fail.
+     * <p>
+     * <strong>Start state:</strong> A {@link Boulder} &rarr; {@link Stone}
+     * &rarr; {@link Pebble} graph saved with {@link Stone#core} set to a single
+     * pebble, then the pebble record cleared. Concourse permits {@link Link
+     * Links} to empty records, so clearing the target leaves the outgoing
+     * {@link Link} on {@link Stone} intact &mdash; the very condition the
+     * cleanup branch in {@code Record#convert(...)} is supposed to handle.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Create and save the {@link Boulder} graph with a single
+     * {@link Pebble} on {@link Stone#core}.</li>
+     * <li>Call {@code client.clear(...)} on the core pebble's id.</li>
+     * <li>Reload the {@link Boulder} via
+     * {@code runway.load(Boulder.class, id)}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The reload completes without throwing,
+     * {@code boulder.stone.core} is {@code null}, and the dangling {@link Link}
+     * has been removed from {@link Stone Stone's} {@code core} stored data.
+     */
+    @Test
+    public void testNestedDanglingScalarFieldClearedOnLoad() {
+        Pebble core = new Pebble();
+        core.label = "delta";
+        Stone stone = new Stone();
+        stone.label = "s";
+        stone.core = core;
+        Boulder boulder = new Boulder();
+        boulder.label = "b";
+        boulder.stone = stone;
+        runway.save(boulder, stone, core);
+
+        client.clear(core.id());
+
+        Boulder loaded = runway.load(Boulder.class, boulder.id());
+        Assert.assertNotNull(loaded);
+        Assert.assertNotNull(loaded.stone);
+        Assert.assertNull(loaded.stone.core);
+        Assert.assertEquals(0, client.select("core", stone.id()).size());
+    }
+
+    /**
      * Leaf-level {@link Record} used as the dangling-link target.
      */
     class Pebble extends Record {
@@ -118,10 +172,11 @@ public class GH94 extends RunwayBaseClientServerTest {
     }
 
     /**
-     * Mid-level {@link Record} that holds a collection of {@link Pebble
-     * Pebbles}. When loaded as a nested {@link Record} of {@link Boulder}, its
-     * fields are processed under prefix {@code "stone."}, which exercises the
-     * path-vs-key conflation in {@code Record#convert(...)}.
+     * Mid-level {@link Record} that holds nested {@link Pebble} references.
+     * When loaded as a nested {@link Record} of {@link Boulder}, its fields are
+     * processed under prefix {@code "stone."}, which exercises the path-vs-key
+     * conflation in {@code Record#convert(...)} on both the collection and
+     * scalar branches of the nested-load logic.
      */
     class Stone extends Record {
 
@@ -135,6 +190,12 @@ public class GH94 extends RunwayBaseClientServerTest {
          * loaded by the collection branch of the nested-load logic.
          */
         List<Pebble> pebbles = new ArrayList<>();
+
+        /**
+         * A scalar nested {@link Pebble} reference loaded by the scalar branch
+         * of the nested-load logic.
+         */
+        Pebble core;
     }
 
     /**

--- a/src/test/java/com/cinchapi/runway/GH94.java
+++ b/src/test/java/com/cinchapi/runway/GH94.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2013-2026 Cinchapi Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.cinchapi.runway;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.cinchapi.concourse.Link;
+
+/**
+ * Repro GH-94 https://github.com/cinchapi/runway/issues/94
+ * <p>
+ * When a {@link Record} is loaded as a nested record from a parent's
+ * pre-fetched data, the inner {@code convert(...)} method is passed the
+ * navigation path (e.g. {@code "stone.pebbles"}) under a parameter named
+ * {@code key}. The dangling-link cleanup branch then forwards that path-shaped
+ * value to {@code concourse.remove(...)}, which rejects it with
+ * {@code InvalidArgumentException} because Concourse keys cannot contain dots.
+ * The result is that any record graph containing a dangling {@link Link} at
+ * depth becomes unloadable until the dangling {@link Link} is removed by hand.
+ *
+ * @author Jeff Nelson
+ */
+public class GH94 extends RunwayBaseClientServerTest {
+
+    /**
+     * <strong>Goal:</strong> Verify that loading a {@link Boulder} whose
+     * deeply-nested {@link Stone} &rarr; {@link Pebble} collection contains a
+     * dangling element (a {@link Link} whose target has been cleared) does not
+     * throw {@code InvalidArgumentException} from the dangling-link cleanup
+     * logic.
+     * <p>
+     * The {@link Stone#pebbles} field is loaded under prefix {@code "stone."},
+     * so each per-element {@code convert(...)} call sees the navigation path
+     * {@code "stone.pebbles"} (a Concourse-invalid key) instead of the
+     * canonical field name {@code "pebbles"}, causing the cleanup of the
+     * dangling element to fail.
+     * <p>
+     * <strong>Start state:</strong> A {@link Boulder} &rarr; {@link Stone}
+     * &rarr; {@link List List&lt;Pebble&gt;} graph saved with three pebbles,
+     * then one of the pebble records cleared. Concourse permits {@link Link
+     * Links} to empty records, so clearing the target leaves the outgoing
+     * {@link Link} on {@link Stone} intact &mdash; the very condition the
+     * cleanup branch in {@code Record#convert(...)} is supposed to handle.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Create and save the {@link Boulder} graph with three {@link Pebble
+     * Pebbles} on {@link Stone#pebbles}.</li>
+     * <li>Call {@code client.clear(...)} on the second pebble's id.</li>
+     * <li>Reload the {@link Boulder} via
+     * {@code runway.load(Boulder.class, id)}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The reload completes without throwing,
+     * {@code boulder.stone.pebbles} contains exactly the two surviving
+     * {@link Pebble Pebbles}, and the dangling {@link Link} has been removed
+     * from {@link Stone Stone's} {@code pebbles} stored data.
+     */
+    @Test
+    public void testNestedDanglingCollectionElementClearedOnLoad() {
+        Pebble p1 = new Pebble();
+        p1.label = "alpha";
+        Pebble p2 = new Pebble();
+        p2.label = "beta";
+        Pebble p3 = new Pebble();
+        p3.label = "gamma";
+        Stone stone = new Stone();
+        stone.label = "s";
+        stone.pebbles.add(p1);
+        stone.pebbles.add(p2);
+        stone.pebbles.add(p3);
+        Boulder boulder = new Boulder();
+        boulder.label = "b";
+        boulder.stone = stone;
+        runway.save(boulder, stone, p1, p2, p3);
+
+        client.clear(p2.id());
+
+        Boulder loaded = runway.load(Boulder.class, boulder.id());
+        Assert.assertNotNull(loaded);
+        Assert.assertNotNull(loaded.stone);
+        Assert.assertEquals(2, loaded.stone.pebbles.size());
+        Set<String> labels = loaded.stone.pebbles.stream().map(p -> p.label)
+                .collect(Collectors.toSet());
+        Assert.assertTrue(labels.contains("alpha"));
+        Assert.assertTrue(labels.contains("gamma"));
+        Assert.assertEquals(2, client.select("pebbles", stone.id()).size());
+    }
+
+    /**
+     * Leaf-level {@link Record} used as the dangling-link target.
+     */
+    class Pebble extends Record {
+
+        /**
+         * A simple label for identification in assertions.
+         */
+        String label;
+    }
+
+    /**
+     * Mid-level {@link Record} that holds a collection of {@link Pebble
+     * Pebbles}. When loaded as a nested {@link Record} of {@link Boulder}, its
+     * fields are processed under prefix {@code "stone."}, which exercises the
+     * path-vs-key conflation in {@code Record#convert(...)}.
+     */
+    class Stone extends Record {
+
+        /**
+         * A simple label for identification in assertions.
+         */
+        String label;
+
+        /**
+         * A collection of nested {@link Pebble} references whose elements are
+         * loaded by the collection branch of the nested-load logic.
+         */
+        List<Pebble> pebbles = new ArrayList<>();
+    }
+
+    /**
+     * Top-level {@link Record} whose single nested {@link Stone} field forces
+     * loading of {@link Stone} under prefix {@code "stone."}, the precondition
+     * for reproducing the path-as-key bug at depth.
+     */
+    class Boulder extends Record {
+
+        /**
+         * A simple label for identification in assertions.
+         */
+        String label;
+
+        /**
+         * The nested {@link Stone}.
+         */
+        Stone stone;
+    }
+
+}


### PR DESCRIPTION
## Summary
- Fixes [GH-94](https://github.com/cinchapi/runway/issues/94). `Record.convert` was forwarding the navigation path (e.g. `"stone.pebbles"`) instead of the canonical field name (`"pebbles"`) to `concourse.remove(...)` during the optimistic dangling-link cleanup, so any record graph containing a dangling `Link` inside a nested `Record`'s `Collection<Record>` field threw `InvalidArgumentException` and became unloadable until the dangling `Link` was removed manually.
- Two-line fix at the two `convert(...)` call sites in `Record.load(...)` to pass `key` (already in scope) instead of `path`. `convert` never read the prefixed path — `key` was only used for the cleanup write at line 2692.
- Updates the `convert` Javadoc to spell out that `key` must be a canonical Concourse field name, not a navigation path, so a future refactor doesn't reintroduce the bug.

closes #94 