### PR TITLE
GH-95: Fix NPE when pre-fetched destination data omits a Link target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Version 1.14.6 (TBD)
 * Fixed a bug where loading a `Record` graph that contained a nested `Record` with a dangling `Link` (one whose target had been cleared) inside a `Collection<Record>` field would throw `InvalidArgumentException`, making the graph unloadable until the dangling `Link` was removed manually. ([GH-94](https://github.com/cinchapi/runway/issues/94))
+* Fixed a bug where loading a `Record` under a non-default `CollectionPreSelectStrategy` would throw `NullPointerException` and abort the entire load whenever a `Link` target was missing from the pre-fetched destination data. ([GH-95](https://github.com/cinchapi/runway/issues/95))
 
 #### Version 1.14.5 (April 14, 2026)
 * Fixed a bug where an anonymous audience could not discover access-controlled records that were readable or writable by anonymous unless discoverability was also explicitly granted, unlike non-anonymous audiences who could implicitly discover any record they were permitted to read or write

--- a/src/main/java/com/cinchapi/runway/Record.java
+++ b/src/main/java/com/cinchapi/runway/Record.java
@@ -2690,9 +2690,13 @@ public abstract class Record implements Comparable<Record> {
                     converted = new DeferredReference(target, runway);
                 }
                 else {
-                    Map<String, Set<Object>> data = targets != null
-                            ? targets.get(target)
-                            : concourse.select(target);
+                    Map<String, Set<Object>> data = null;
+                    if(targets != null) {
+                        data = targets.get(target);
+                    }
+                    if(data == null) {
+                        data = concourse.select(target);
+                    }
                     Set<Object> sections = data.getOrDefault(SECTION_KEY,
                             ImmutableSet.of());
                     String section = (String) Iterables.getLast(sections, null);

--- a/src/test/java/com/cinchapi/runway/GH95.java
+++ b/src/test/java/com/cinchapi/runway/GH95.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2013-2026 Cinchapi Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.cinchapi.runway;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.google.common.collect.Maps;
+
+/**
+ * Repro GH-95 https://github.com/cinchapi/runway/issues/95
+ * <p>
+ * When a {@link Record} is loaded under a non-{@code NONE}
+ * {@link CollectionPreSelectStrategy}, {@code Record#convert(...)} reads the
+ * destination data for each {@link com.cinchapi.concourse.Link Link} from the
+ * pre-fetched {@code targets} map. The convert branch unconditionally
+ * dereferences the result of {@code targets.get(target)} on the next line, so
+ * any pre-fetch miss (e.g., the target is a brand-new id, the target's record
+ * was cleared, or the pre-fetch result set was scoped narrower than the actual
+ * link set) triggers a {@link NullPointerException} that aborts the entire
+ * load. Pre-fetching is an optimization, not a contract &mdash; a miss should
+ * degrade to a single record fetch, not crash.
+ *
+ * @author Jeff Nelson
+ */
+public class GH95 extends RunwayBaseClientServerTest {
+
+    /**
+     * <strong>Goal:</strong> Verify that loading a {@link Stone} succeeds when
+     * its pre-fetched {@code targets} map is missing an entry for one of the
+     * {@link com.cinchapi.concourse.Link Links} on {@link Stone#pebbles}.
+     * Without the fix, the convert branch dereferences a {@code null} value
+     * from {@code targets.get(target)}, throwing {@link NullPointerException}
+     * and aborting the entire load. With the fix, the missing entry triggers a
+     * single-record fallback fetch and the referenced {@link Pebble} is
+     * materialized normally.
+     * <p>
+     * <strong>Start state:</strong> A {@link Stone} with three {@link Pebble
+     * Pebbles} saved.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Save a {@link Stone} with three {@link Pebble Pebbles}.</li>
+     * <li>Build a {@code targets} map containing entries for two of the three
+     * {@link Pebble Pebbles}, intentionally omitting the third &mdash;
+     * simulating a pre-fetch result set that diverged from the actual
+     * {@link Link} set on the loaded {@link Stone}.</li>
+     * <li>Call the package-private static {@code Record.load(...)} with the
+     * incomplete {@code targets} map.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The reload completes without throwing,
+     * {@code stone.pebbles} contains all three {@link Pebble Pebbles}, and the
+     * omitted {@link Pebble} is fetched directly from Concourse rather than
+     * read from the {@code targets} map.
+     */
+    @Test
+    public void testLoadFallsBackWhenTargetMissingFromPrefetchMap() {
+        Pebble p1 = new Pebble();
+        p1.label = "alpha";
+        Pebble p2 = new Pebble();
+        p2.label = "beta";
+        Pebble p3 = new Pebble();
+        p3.label = "gamma";
+        Stone stone = new Stone();
+        stone.label = "s";
+        stone.pebbles.add(p1);
+        stone.pebbles.add(p2);
+        stone.pebbles.add(p3);
+        runway.save(stone, p1, p2, p3);
+
+        Map<Long, Map<String, Set<Object>>> targets = Maps.newHashMap();
+        targets.put(p1.id(), client.select(p1.id()));
+        targets.put(p3.id(), client.select(p3.id()));
+
+        Stone loaded = Record.load(Stone.class, stone.id(),
+                new ConcurrentHashMap<>(), runway.connections, runway, null,
+                targets);
+
+        Assert.assertNotNull(loaded);
+        Assert.assertEquals(3, loaded.pebbles.size());
+        List<String> labels = new ArrayList<>();
+        for (Pebble p : loaded.pebbles) {
+            labels.add(p.label);
+        }
+        Assert.assertTrue(labels.contains("alpha"));
+        Assert.assertTrue(labels.contains("beta"));
+        Assert.assertTrue(labels.contains("gamma"));
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that loading a {@link Stone} with a
+     * dangling {@link com.cinchapi.concourse.Link Link} in its
+     * {@link Stone#pebbles} collection succeeds under
+     * {@link CollectionPreSelectStrategy#BULK_SELECT}. This is a regression
+     * test for the interaction between the BULK_SELECT pre-fetch path and the
+     * dangling-link cleanup logic in {@code Record#convert(...)}.
+     * <p>
+     * <strong>Start state:</strong> A {@link Stone} with three {@link Pebble
+     * Pebbles} saved, one of which is then cleared. The
+     * {@link com.cinchapi.concourse.Link Link} on {@link Stone#pebbles}
+     * pointing at the cleared {@link Pebble} survives because Concourse permits
+     * {@link com.cinchapi.concourse.Link Links} to empty records.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Save a {@link Stone} with three {@link Pebble Pebbles}.</li>
+     * <li>Call {@code client.clear(...)} on the second {@link Pebble Pebble's}
+     * id to leave its outgoing {@link com.cinchapi.concourse.Link Link}
+     * dangling.</li>
+     * <li>Switch the {@link Runway} to
+     * {@link CollectionPreSelectStrategy#BULK_SELECT} so pre-fetching is
+     * exercised.</li>
+     * <li>Reload the {@link Stone} via
+     * {@code runway.load(Stone.class, id)}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The reload completes without throwing,
+     * {@code stone.pebbles} contains exactly the two surviving {@link Pebble
+     * Pebbles}, and the dangling {@link com.cinchapi.concourse.Link Link} has
+     * been removed from {@link Stone Stone's} stored {@code pebbles} data.
+     */
+    @Test
+    public void testBulkSelectLoadDoesNotNpeOnDanglingCollectionLink() {
+        Pebble p1 = new Pebble();
+        p1.label = "alpha";
+        Pebble p2 = new Pebble();
+        p2.label = "beta";
+        Pebble p3 = new Pebble();
+        p3.label = "gamma";
+        Stone stone = new Stone();
+        stone.label = "s";
+        stone.pebbles.add(p1);
+        stone.pebbles.add(p2);
+        stone.pebbles.add(p3);
+        runway.save(stone, p1, p2, p3);
+
+        client.clear(p2.id());
+
+        CollectionPreSelectStrategy previous = runway.properties()
+                .collectionPreSelectStrategy();
+        runway.properties().collectionPreSelectStrategy(
+                CollectionPreSelectStrategy.BULK_SELECT);
+        try {
+            Stone loaded = runway.load(Stone.class, stone.id());
+            Assert.assertNotNull(loaded);
+            Assert.assertEquals(2, loaded.pebbles.size());
+            List<String> labels = new ArrayList<>();
+            for (Pebble p : loaded.pebbles) {
+                labels.add(p.label);
+            }
+            Assert.assertTrue(labels.contains("alpha"));
+            Assert.assertTrue(labels.contains("gamma"));
+            Assert.assertEquals(2, client.select("pebbles", stone.id()).size());
+        }
+        finally {
+            runway.properties().collectionPreSelectStrategy(previous);
+        }
+    }
+
+    /**
+     * Leaf-level {@link Record} used as the {@link com.cinchapi.concourse.Link
+     * Link} target for {@link Stone#pebbles}.
+     */
+    class Pebble extends Record {
+
+        /**
+         * A simple label for identification in assertions.
+         */
+        String label;
+    }
+
+    /**
+     * {@link Record} that holds a {@link List List&lt;Pebble&gt;} field, used
+     * to drive the collection branch of {@code Record#convert(...)}.
+     */
+    class Stone extends Record {
+
+        /**
+         * A simple label for identification in assertions.
+         */
+        String label;
+
+        /**
+         * A collection of nested {@link Pebble} references whose elements are
+         * loaded by the collection branch of the nested-load logic.
+         */
+        List<Pebble> pebbles = new ArrayList<>();
+    }
+
+}


### PR DESCRIPTION
## Summary
- `Record#convert(...)` unconditionally dereferenced `targets.get(target)` when a non-default `CollectionPreSelectStrategy` was active, so any pre-fetch miss (e.g., the target is a brand-new id, the target's record was cleared, or the pre-fetch result set was scoped narrower than the actual link set) threw `NullPointerException` and aborted the entire load.
- The fix replaces the unconditional ternary in `Record.java` with explicit branches that fall back to `concourse.select(target)` whenever `targets` is `null` or lacks an entry for the target. Pre-fetching is an optimization, not a contract — a miss should degrade to a single-record fetch, not crash.
- Added `GH95` with a white-box test that builds a `targets` map missing one of the saved children's ids and asserts the load completes with all three children materialized, plus a regression test that covers the dangling-link interaction with `BULK_SELECT`.