### PR TITLE
Move read finalization from Reader onto Selection

### DIFF
--- a/src/main/java/com/cinchapi/runway/DatabaseSelection.java
+++ b/src/main/java/com/cinchapi/runway/DatabaseSelection.java
@@ -127,17 +127,21 @@ abstract class DatabaseSelection<T extends Record> implements Selection<T> {
     volatile Selection<?> origin;
 
     /**
-     * The unfiltered result to store in the reservation cache. When a
-     * {@link #filter} is applied, the {@link #result} contains filtered data
-     * that must not be cached under a filterless key. This field holds the
-     * pre-filter data so that {@code reserve()} can cache it instead.
-     * <p>
-     * {@code null} means no separate cache value was captured — either because
-     * no filter was applied or because the execution path could not separate
-     * filtered from unfiltered results.
+     * The unfiltered companion to {@link #result}, populated when a client-side
+     * {@link #filter} has narrowed {@link #result} but the pre-filter value is
+     * still required downstream. {@code null} when no separate unfiltered value
+     * was captured.
      */
     @Nullable
     Object cacheValue;
+
+    /**
+     * The finisher attached during dispatch that applies this
+     * {@link DatabaseSelection DatabaseSelection's} read result to its state.
+     * {@code null} before dispatch and after {@link #drain()} has run.
+     */
+    @Nullable
+    private Runnable finisher;
 
     /**
      * Construct a new {@link DatabaseSelection}.
@@ -268,6 +272,30 @@ abstract class DatabaseSelection<T extends Record> implements Selection<T> {
     }
 
     /**
+     * Attach the {@code finisher} that {@link #drain()} will run to apply this
+     * {@link DatabaseSelection DatabaseSelection's} read result to its state.
+     * Replaces any previously attached finisher.
+     *
+     * @param finisher the work that materializes this {@link DatabaseSelection}
+     */
+    void attach(Runnable finisher) {
+        this.finisher = finisher;
+    }
+
+    /**
+     * Run the attached finisher, applying this {@link DatabaseSelection
+     * DatabaseSelection's} read result to its state. No-op when no finisher is
+     * attached or when this {@link DatabaseSelection} has already been drained.
+     */
+    void drain() {
+        Runnable f = finisher;
+        if(f != null) {
+            finisher = null;
+            f.run();
+        }
+    }
+
+    /**
      * Return {@code true} if this {@link DatabaseSelection} can be combined
      * with other {@link DatabaseSelection Selections} in a single database
      * call.
@@ -295,10 +323,9 @@ abstract class DatabaseSelection<T extends Record> implements Selection<T> {
     }
 
     /**
-     * Return the {@link Reservation} that represents the canonical cache key
-     * for this {@link DatabaseSelection}. Two {@link DatabaseSelection
-     * DatabaseSelections} with equivalent configuration produce equal
-     * {@link Reservation Reservations}.
+     * Return the {@link Reservation} for this {@link DatabaseSelection}. Two
+     * {@link DatabaseSelection DatabaseSelections} with equivalent
+     * configuration produce equal {@link Reservation Reservations}.
      *
      * @return the {@link Reservation} for this {@link DatabaseSelection}
      */

--- a/src/main/java/com/cinchapi/runway/Runway.java
+++ b/src/main/java/com/cinchapi/runway/Runway.java
@@ -2036,6 +2036,14 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
                     "Unsupported Selection type " + selection.getClass());
         }
         selection.attach(() -> {
+            // NOTE: supplier.get() is the trigger that materializes the
+            // read recorded against the Reader. For batching Readers, the
+            // first .get() across a shared batch submits the underlying
+            // round trip and stores the result list on the batch; sibling
+            // suppliers from the same batch reuse it on subsequent .get()
+            // calls. For eagerly-issued Readers the round trip already
+            // happened at recording time and .get() just returns the
+            // captured value.
             SelectResult<?> res = supplier.get();
             ((DatabaseSelection) selection).setResult(res.result);
             selection.cacheValue = res.cacheValue;

--- a/src/main/java/com/cinchapi/runway/Runway.java
+++ b/src/main/java/com/cinchapi/runway/Runway.java
@@ -979,7 +979,7 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
                     concourse = ensureValidConnection(concourse);
                     Reader reader = new ImmediateReader(concourse);
                     $select(reader, selection);
-                    reader.drain();
+                    selection.drain();
                     reserve(selection);
                 }
                 return new Selections(selections);
@@ -1004,10 +1004,8 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
                             dispatched.add(selection);
                         }
                     }
-                    if(reader != null) {
-                        reader.drain();
-                    }
                     for (DatabaseSelection<?> selection : dispatched) {
+                        selection.drain();
                         reserve(selection);
                     }
                 }
@@ -1038,7 +1036,7 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
                             Reader reader = new ImmediateReader(concourse);
                             $selectWithPossibleSources(reader, selection,
                                     sources);
-                            reader.drain();
+                            selection.drain();
                             reserve(selection);
                             continue outer;
                         }
@@ -1097,7 +1095,7 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
                                     Reader reader = new ImmediateReader(
                                             _concourse);
                                     $select(reader, selection);
-                                    reader.drain();
+                                    selection.drain();
                                 }
                                 finally {
                                     connections.release(_concourse);
@@ -1980,8 +1978,8 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
     /**
      * Resolve {@code selection}, recording any required reads on {@code reader}
      * and mutating {@code selection} with its result. Database-bound resolution
-     * is deferred to {@link Reader#drain() reader.drain()}; all other paths
-     * mutate {@code selection} immediately.
+     * is deferred to {@link DatabaseSelection#drain() selection.drain()}; all
+     * other paths mutate {@code selection} immediately.
      *
      * @param reader the {@link Reader} that records any required reads
      * @param selection the {@link DatabaseSelection} to resolve
@@ -2037,7 +2035,7 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
             throw new IllegalStateException(
                     "Unsupported Selection type " + selection.getClass());
         }
-        reader.onDrain(() -> {
+        selection.attach(() -> {
             SelectResult<?> res = supplier.get();
             ((DatabaseSelection) selection).setResult(res.result);
             selection.cacheValue = res.cacheValue;

--- a/src/main/java/com/cinchapi/runway/db/AbstractReader.java
+++ b/src/main/java/com/cinchapi/runway/db/AbstractReader.java
@@ -15,41 +15,21 @@
  */
 package com.cinchapi.runway.db;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import com.cinchapi.concourse.Concourse;
 import com.google.common.base.Preconditions;
 
 /**
  * Base class for {@link Reader} implementations that wrap a single
- * {@link Concourse} connection. Provides shared bookkeeping for completions
- * registered via {@link #onDrain(Runnable)} and a {@link #drain()} template
- * that delegates the implementation-specific flush step to
- * {@link #prepareDrain()}.
+ * {@link Concourse} connection.
  *
  * @author Jeff Nelson
  */
 public abstract class AbstractReader implements Reader {
 
     /**
-     * The {@link Concourse} connection against which reads are issued or
-     * submitted.
+     * The {@link Concourse} connection against which reads are issued.
      */
     protected final Concourse concourse;
-
-    /**
-     * Completions registered via {@link #onDrain(Runnable)} and run by
-     * {@link #drain()} in registration order.
-     */
-    private final List<Runnable> completions;
-
-    /**
-     * Whether the deferred reads have been issued (drained); when {@code true},
-     * subsequent {@link #drain()} calls are no-ops regardless of whether every
-     * completion ran.
-     */
-    private boolean drained;
 
     /**
      * Construct a new {@link AbstractReader}.
@@ -59,42 +39,11 @@ public abstract class AbstractReader implements Reader {
      */
     protected AbstractReader(Concourse concourse) {
         this.concourse = Preconditions.checkNotNull(concourse);
-        this.completions = new ArrayList<>();
-        this.drained = false;
     }
 
     @Override
     public final Concourse concourse() {
         return concourse;
     }
-
-    @Override
-    public final void onDrain(Runnable completion) {
-        completions.add(Preconditions.checkNotNull(completion));
-    }
-
-    @Override
-    public final void drain() {
-        if(drained) {
-            return;
-        }
-        prepareDrain();
-        drained = true;
-        try {
-            for (Runnable completion : completions) {
-                completion.run();
-            }
-        }
-        finally {
-            completions.clear();
-        }
-    }
-
-    /**
-     * Issue any deferred work (e.g., submit a batched
-     * {@link com.cinchapi.concourse.lang.CommandGroup CommandGroup}) before
-     * {@link #onDrain registered completions} run.
-     */
-    protected abstract void prepareDrain();
 
 }

--- a/src/main/java/com/cinchapi/runway/db/EventualReader.java
+++ b/src/main/java/com/cinchapi/runway/db/EventualReader.java
@@ -31,24 +31,8 @@ import com.google.common.collect.ImmutableList;
 
 /**
  * A {@link Reader} that batches recorded reads into a single
- * {@link Concourse#submit(CommandGroup) submission}.
- * <p>
- * Each recording method appends a command to the active batch and returns a
- * {@link Supplier} bound to it; the call does not contact the database. The
- * batch is submitted &mdash; in a single round trip &mdash; on {@link #drain()}
- * or on the first {@link Supplier#get()} against any of the bound
- * {@link Supplier Suppliers}, whichever comes first. After submission, every
- * bound {@link Supplier} yields its corresponding result.
- * </p>
- * <p>
- * If submission fails, the exception is rethrown on every subsequent
- * {@link Supplier#get()} call against any {@link Supplier} bound to the failed
- * batch, so sibling {@link Supplier Suppliers} cannot observe divergent
- * outcomes.
- * </p>
- * <p>
- * Recording calls made after a submission start a fresh batch.
- * </p>
+ * {@link Concourse#submit(CommandGroup) submission} so that all reads recorded
+ * against the same batch share a single round trip.
  * <p>
  * This {@link Reader} is <strong>not thread-safe</strong>.
  * </p>
@@ -226,13 +210,6 @@ public final class EventualReader extends AbstractReader {
         int slot = batch.size();
         batch.group.count(key, criteria);
         return () -> ((Number) batch.flush(concourse).get(slot)).longValue();
-    }
-
-    @Override
-    protected void prepareDrain() {
-        if(!current.flushed() && current.size() > 0) {
-            current.flush(concourse);
-        }
     }
 
     /**

--- a/src/main/java/com/cinchapi/runway/db/ImmediateReader.java
+++ b/src/main/java/com/cinchapi/runway/db/ImmediateReader.java
@@ -171,7 +171,4 @@ public class ImmediateReader extends AbstractReader {
         return () -> result;
     }
 
-    @Override
-    protected void prepareDrain() {/* no-op */}
-
 }

--- a/src/main/java/com/cinchapi/runway/db/Reader.java
+++ b/src/main/java/com/cinchapi/runway/db/Reader.java
@@ -26,22 +26,7 @@ import com.cinchapi.concourse.lang.sort.Order;
 
 /**
  * A {@link Reader} records reads against a database and returns a
- * {@link Supplier} for each one.
- * <p>
- * The first call to {@link Supplier#get()} on any {@link Supplier} returned
- * from this {@link Reader} guarantees that the underlying read has been
- * executed against the database and yields its result. Implementations decide
- * <em>when</em> the underlying read is executed &mdash; eagerly at recording
- * time, batched and submitted on {@link #drain()}, or by some other strategy
- * &mdash; but the contract from a caller's perspective is the same: record,
- * then {@code get()}.
- * </p>
- * <p>
- * Callers that record multiple reads and want to fan out the resolution work
- * register completion {@link Runnable Runnables} via
- * {@link #onDrain(Runnable)}. {@link #drain()} issues any deferred reads and
- * then runs every registered completion in registration order.
- * </p>
+ * {@link Supplier} for each one that yields the read's result.
  *
  * @author Jeff Nelson
  */
@@ -245,30 +230,5 @@ public interface Reader {
      * @return the {@link Concourse} connection
      */
     Concourse concourse();
-
-    /**
-     * Register a completion {@link Runnable} to run inside {@link #drain()}.
-     * Completions run in registration order, after any deferred reads have been
-     * issued.
-     *
-     * @param completion the work to run when this {@link Reader} drains
-     */
-    void onDrain(Runnable completion);
-
-    /**
-     * Issue any deferred reads recorded on this {@link Reader} and run every
-     * {@link #onDrain registered completion} in registration order.
-     * <p>
-     * Once the deferred reads have been issued this {@link Reader} is drained;
-     * subsequent calls are no-ops even when a completion threw mid-iteration,
-     * in which case the remaining completions are discarded. If the deferred
-     * read submission itself fails, this {@link Reader} is not marked drained
-     * and a subsequent call may retry.
-     * </p>
-     *
-     * @throws RuntimeException if a deferred submission fails; no completions
-     *             run in that case
-     */
-    void drain();
 
 }


### PR DESCRIPTION
## Summary

Experimental refactor of the read-resolution machinery, sketched in conversation. Targets `feature/integrate-command-api` so the delta against the current design can be reviewed in isolation.

- **`Reader.drain()` / `Reader.onDrain(Runnable)` are removed.** `Reader` collapses to a `Supplier`-factory interface: record a read, get back a `Supplier<T>` that yields its result.
- **`DatabaseSelection` gains a finisher slot.** A private `Runnable finisher` field, package-private `attach(Runnable)` / `drain()` methods. The finisher is parked by `$select` at dispatch time and run by the caller per-selection.
- **Call sites loop by selection.** Every `reader.drain()` site becomes `selection.drain()`; the bulk multi-select branch folds materialization into the same loop that runs `reserve()`.

## Why

`Reader` previously held a list of `Runnable` completions that closed over `Selection` state — the low-level Reader was a parking lot for closures owned by a higher-level concern. `drain()` was the only way to fire them, which created an asymmetry with `supplier.get()` (flushes the batch but does not run completions, so a caller who took the supplier path silently skipped finalization).

After this change:

- `Reader` knows about suppliers and batches. That is its entire responsibility.
- `DatabaseSelection` knows how to finalize itself. The finisher lives next to the state it mutates.
- `$select` is the only place that wires both layers; it builds the supplier on the `Reader`, builds the finisher that consumes it, and parks the finisher on the `Selection`.

The shared `EventualReader` batch behavior is unchanged: every supplier still closes over the same `Batch`, and the first `supplier.get()` still triggers `Batch.flush(concourse)` and caches the result list for sibling suppliers.

## Diff shape

| File | Change |
|---|---|
| `db/Reader.java` | Drop `drain()`, `onDrain(Runnable)`, related Javadoc |
| `db/AbstractReader.java` | Drop completions list, `drain()` template, `prepareDrain()` hook |
| `db/EventualReader.java` | Drop `prepareDrain()` |
| `db/ImmediateReader.java` | Drop `prepareDrain()` |
| `DatabaseSelection.java` | Add `finisher` field, `attach(Runnable)`, `drain()` |
| `Runway.java` | Replace `reader.onDrain(...)` with `selection.attach(...)`; replace 4 `reader.drain()` call sites with per-selection `selection.drain()` |

Net: **+51 / −143**.

## Notes / things to weigh in review

- **`drain()` on `Selection` carries Reader-vocabulary baggage.** Easy to rename to `complete()`, `resolve()`, `finalize()` (taken), or similar without changing semantics. Left as `drain()` for clarity vs. the prior API.
- **The `reader` parameter is now unused at the `$selectWithPossibleSources` tail** (the `selection.attach(...)` call doesn't need it; only the supplier-building methods above it do). The parameter still has callers' uses, just not at that exact site.
- **No new tests yet.** The existing `ReaderTest` / `EventualReaderTest` / `ImmediateReaderTest` tests only exercise `Supplier`-level behavior (recording + `.get()`), which is preserved. The integration-level coverage of finisher attachment lives in `Runway` paths that exercise it.
- **Failure localization changes shape.** Previously a `drain()` failure aborted every queued completion. Now a `Batch` flush failure latches and rethrows on every sibling supplier (unchanged); a finisher failure during `selection.drain()` is scoped to that selection alone (other selections in `dispatched` are untouched until their own `drain()` call). Worth a deliberate decision before merging.

## Test plan

- [ ] `./gradlew compileJava compileTestJava` — passes locally
- [ ] `./gradlew spotlessApply` — clean
- [ ] Existing `EventualReaderTest` (batch share + failure latch) — behavior unchanged
- [ ] `BulkMultiSelectIntegrationTest` against a 1.0.0-rc server — verifies the bulk path still folds into one round trip
- [ ] Spot-check `ReservationFilterPoisoningTest` and `RunwayQueryTest` for any path that exercised `reader.drain()` or `onDrain()` — only Runway internals referenced these, so external tests should be unaffected
