### PR TITLE
GH-99: Adopt branch-based publishing channels

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,9 +123,9 @@ build counter and a branch-derived suffix:
 | Branch pattern   | Version produced         |
 |------------------|--------------------------|
 | `master`         | `1.0.0.42`               |
-| `release/*`      | `1.0.0.42`               |
+| `release/*`      | `1.0.0.42-rc`            |
 | `develop`        | `1.0.0.42-SNAPSHOT`      |
-| `feature/foo`    | `1.0.0.42-FOO`           |
+| `feature/foo`    | `1.0.0.42-FEATURE-FOO`   |
 
 To set a new base version:
 

--- a/build.gradle
+++ b/build.gradle
@@ -99,12 +99,24 @@ def getVersion = { ->
 
 group = 'com.cinchapi'
 version = getVersion()
-// Drop the build component from version number and use that for
-// publishing
-ext.mavenVersion = version.split('\\.')
-ext.mavenVersion[3] = ext.mavenVersion[3].replaceAll("[0-9]+-", "-")
-ext.mavenVersion[3] = ext.mavenVersion[3].replaceAll("[0-9]+", "").trim()
-ext.mavenVersion = ext.mavenVersion.join(".").replace(".-", "-").replaceAll('\\.$', "")
+
+// Derive the Maven coordinate from the internal 4-segment version.
+// For -rc, lift the build counter into the suffix so each RC push
+// produces a unique, immutable artifact (e.g. 2.0.0.42-rc ->
+// 2.0.0-rc42). For every other shape, strip the counter and
+// preserve any pre-release suffix.
+ext.mavenVersion = version
+    .replaceFirst(/^(\d+\.\d+\.\d+)\.(\d+)-rc$/, '$1-rc$2')
+    .replaceFirst(/^(\d+\.\d+\.\d+)\.\d+(.*)$/, '$1$2')
+
+// Strict predicate for GA-only destinations. Matches both the
+// 3-segment Maven form (2.0.0) and the 4-segment internal form
+// (2.0.0.42). Rejects -SNAPSHOT, -rc<N>, feature suffixes, and
+// any other pre-release qualifier, so non-GA builds can never
+// route to the Cloudsmith releases repo.
+ext.isGAVersion = { version ->
+    return (version =~/^\d+\.\d+\.\d+(\.\d+)?$/).matches()
+}
 
 jar {
     manifest {
@@ -133,7 +145,9 @@ publishing {
       name = 'cloudsmith'
       def releasesRepoUrl = "https://api-g.cloudsmith.io/maven/cinchapi/open-source/"
       def snapshotsRepoUrl = "https://api-g.cloudsmith.io/maven/cinchapi/open-source-snapshots/"
-      url = mavenVersion.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+      // Only clean GA versions go to the releases repo; everything
+      // else (SNAPSHOT, -rc<N>, feature suffixes) goes to snapshots.
+      url = isGAVersion(mavenVersion) ? releasesRepoUrl : snapshotsRepoUrl
       credentials {
         username = System.getenv('CLOUDSMITH_API_USER')
         password = System.getenv('CLOUDSMITH_API_KEY')

--- a/version.sh
+++ b/version.sh
@@ -46,7 +46,9 @@ fi
 
 if [ -z "$1" ] ; then
   VERSION=`cat $BASE_VERSION_FILE`
-  BRANCH=`git rev-parse --abbrev-ref HEAD`
+  # CI environments often check out in detached HEAD state, so prefer
+  # CI-provided environment variables over git commands.
+  BRANCH="${CIRCLE_BRANCH:-${GITHUB_HEAD_REF:-${GITHUB_REF_NAME:-${BRANCH_NAME:-${CI_COMMIT_BRANCH:-${GIT_BRANCH:-$(git rev-parse --abbrev-ref HEAD)}}}}}}"
   COMMIT=`git rev-parse HEAD | cut -c1-10`
 
   # Get counter value
@@ -64,24 +66,28 @@ if [ -z "$1" ] ; then
   fi
   echo $COUNTER > $COUNTER_FILE
   VERSION=$VERSION.$COUNTER
+  # master is the only branch that produces a clean GA version.
+  # Every other branch gets a suffix that keeps its artifacts in the
+  # Cloudsmith snapshots repo, never the releases repo.
   case $BRANCH in
+    master )
+      EXTRA=""
+      ;;
+    release/* )
+      EXTRA="-rc"
+      ;;
     develop )
       EXTRA="-SNAPSHOT"
       ;;
-    feature* )
-      IFS='/'
-      PARTS=( $BRANCH )
-      EXTRA="-${PARTS[1]}"
-      EXTRA=`echo $EXTRA | tr '[:lower:]' '[:upper:]'`
-      ;;
-    release* )
-      EXTRA=""
-      ;;
     * )
-      # At this point we do not need to refer
-      # to any commit hash since we'll have a
-      # tag that represents the overall release
-      EXTRA=""
+      # Sanitize the full branch name into a Maven-safe suffix:
+      # uppercase, collapse non-alphanumerics to '-', trim, cap at
+      # 32, fall back to BUILD if empty.
+      SUFFIX=$(echo "$BRANCH" | tr '[:lower:]' '[:upper:]' \
+        | sed -E 's/[^A-Z0-9]+/-/g; s/^-+//; s/-+$//')
+      SUFFIX=${SUFFIX:0:32}
+      SUFFIX=${SUFFIX:-BUILD}
+      EXTRA="-${SUFFIX}"
       ;;
   esac
   echo $VERSION$EXTRA


### PR DESCRIPTION
## Summary

Adapts [concourse#729](https://github.com/cinchapi/concourse/pull/729)'s branch-based publishing channels to Runway. Today the CI `publish` job runs on every branch and picks the Cloudsmith repo purely by version string, so `feature/*`, `release/*`, and ad-hoc branches all leak into the GA **releases** repo — only `develop`'s `-SNAPSHOT` was correctly excluded.

- **`version.sh`**: branch detection falls back through CI environment variables so detached-HEAD checkouts resolve correctly. `master` is now the only branch that produces a clean GA version; `release/*` → `-rc`; `develop` → `-SNAPSHOT`; every other branch gets a sanitized full-name suffix.
- **`build.gradle`**: a new two-pass `mavenVersion` derivation lifts the build counter into a unique, immutable `-rc<N>` coordinate. A strict `isGAVersion` predicate gates Cloudsmith routing so only clean GA versions reach the releases repo.

Runway has no Sonatype/Maven Central publishing, Docker image, or `.bin` installer, so those pieces of concourse#729 do not apply and were dropped.

### Per-branch outcome

| Branch | `mavenVersion` | Cloudsmith repo | vs. today |
|---|---|---|---|
| `master` | `2.0.0` | `open-source/` (releases) | unchanged |
| `develop` | `2.0.0-SNAPSHOT` | `open-source-snapshots/` | unchanged |
| `release/2.0.0` | `2.0.0-rc42` | `open-source-snapshots/` | was: clean `2.0.0` → releases |
| `feature/foo` | `2.0.0-FEATURE-FOO` | `open-source-snapshots/` | was: `2.0.0-FOO` → releases |
| `bugfix/*` etc. | `2.0.0-BUGFIX-*` | `open-source-snapshots/` | was: clean `2.0.0` → releases |

**Behavior change:** feature-branch snapshots change coordinate from `2.0.0-FOO` to `2.0.0-FEATURE-FOO` (full sanitized branch name), which eliminates cross-prefix collisions (`feature/foo` and `bugfix/foo` both produced `-FOO`).

**Not changed:** `.circleci/config.yml` (separation is enforced by the version string + routing, not branch filters), the JAR manifest's internal 4-segment version (a pre-existing cosmetic mismatch concourse#729 also left), and `CHANGELOG.md` (build infrastructure — the GA/SNAPSHOT coordinates consumers actually use are unchanged).

## Test plan

- [x] `version.sh` exercised across `master`, `release/2.0.0`, `develop`, `feature/foo`, `bugfix/auth-fix`, lexical near-misses (`releases`, `release-notes/v2`), an empty branch, and an over-long name — each produces the expected suffix, the 32-char cap holds, and near-misses do not pick up `-rc`.
- [x] `mavenVersion` + `isGAVersion` verified with the exact Groovy logic: all version shapes route to the expected repo (only `master` → releases; the `-rc` counter is correctly lifted into the suffix).
- [ ] CI on `master`: clean GA version lands in Cloudsmith `open-source/`.
- [ ] CI on `release/*`: unique `-rc<N>` lands in `open-source-snapshots/`.
- [ ] CI on `develop`: `-SNAPSHOT` lands in `open-source-snapshots/` (unchanged).
- [ ] CI on a `feature/*` or ad-hoc branch: sanitized suffix lands in `open-source-snapshots/`.

Closes #99.
