### PR TITLE
Checkpoint Records with a server time recorded on the batch

### DIFF
--- a/src/main/java/com/cinchapi/runway/Record.java
+++ b/src/main/java/com/cinchapi/runway/Record.java
@@ -46,6 +46,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
+import java.util.function.LongSupplier;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -170,6 +171,44 @@ public abstract class Record implements Comparable<Record> {
             }
         }
         return true;
+    }
+
+    /**
+     * The server timestamp, in microseconds, as of which the {@link Record}
+     * being loaded on the current thread reflects the database, or {@code null}
+     * when no load is in progress on this thread.
+     */
+    private static final ThreadLocal<Long> LOAD_CHECKPOINT = new ThreadLocal<>();
+
+    /**
+     * Run {@code load} with {@code checkpoint} established as the load
+     * checkpoint for every {@link Record} materialized on the current thread
+     * while it runs.
+     * <p>
+     * Re-entrant: a nested call inherits the checkpoint already in scope rather
+     * than replacing it, so an entire load &mdash; a {@link Record} and every
+     * {@link Record} linked from it &mdash; shares one checkpoint.
+     * {@code checkpoint} is evaluated only when this call establishes the
+     * scope, never when it inherits one.
+     *
+     * @param checkpoint supplies the server timestamp, in microseconds, as of
+     *            which the load reflects the database
+     * @param load the load to run
+     * @return the result of {@code load}
+     */
+    static <T> T withLoadCheckpoint(LongSupplier checkpoint, Supplier<T> load) {
+        if(LOAD_CHECKPOINT.get() != null) {
+            return load.get();
+        }
+        else {
+            LOAD_CHECKPOINT.set(checkpoint.getAsLong());
+            try {
+                return load.get();
+            }
+            finally {
+                LOAD_CHECKPOINT.remove();
+            }
+        }
     }
 
     /**
@@ -2182,7 +2221,9 @@ public abstract class Record implements Comparable<Record> {
             }
         }
         __checksum = checksum();
-        checkpoint(concourse.time().getMicros());
+        Long loadCheckpoint = LOAD_CHECKPOINT.get();
+        checkpoint(loadCheckpoint != null ? loadCheckpoint
+                : concourse.time().getMicros());
     }
 
     /**

--- a/src/main/java/com/cinchapi/runway/Record.java
+++ b/src/main/java/com/cinchapi/runway/Record.java
@@ -46,7 +46,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
-import java.util.function.LongSupplier;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -101,7 +100,6 @@ import com.cinchapi.runway.util.ComputedEntry;
 import com.cinchapi.runway.validation.Validator;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicates;
-import com.google.common.base.Suppliers;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -175,75 +173,6 @@ public abstract class Record implements Comparable<Record> {
     }
 
     /**
-     * The load checkpoint &mdash; a server timestamp, in microseconds, as of
-     * which the {@link Record Records} materialized on the current thread
-     * reflect the database &mdash; for the load in progress on this thread, or
-     * {@code null} when no load is in progress.
-     */
-    private static final ThreadLocal<Supplier<Long>> LOAD_CHECKPOINT = new ThreadLocal<>();
-
-    /**
-     * Run {@code load} with {@code checkpoint} established as the load
-     * checkpoint for every {@link Record} materialized on the current thread
-     * while it runs.
-     * <p>
-     * Re-entrant: a nested call shares the checkpoint already in scope rather
-     * than establishing a new one, so an entire load &mdash; a {@link Record}
-     * and every {@link Record} linked from it &mdash; shares one checkpoint.
-     *
-     * @param checkpoint supplies the server timestamp, in microseconds, as of
-     *            which the load reflects the database
-     * @param load the load to run
-     * @return the result of {@code load}
-     */
-    static <T> T withLoadCheckpoint(LongSupplier checkpoint, Supplier<T> load) {
-        if(LOAD_CHECKPOINT.get() != null) {
-            return load.get();
-        }
-        else {
-            LOAD_CHECKPOINT.set(Suppliers.memoize(checkpoint::getAsLong));
-            try {
-                return load.get();
-            }
-            finally {
-                LOAD_CHECKPOINT.remove();
-            }
-        }
-    }
-
-    /**
-     * Resolve the load checkpoint for the current thread now, if a load is in
-     * progress.
-     * <p>
-     * Call this immediately before issuing a read that materializes
-     * {@link Record Records} so the checkpoint reflects a server time at or
-     * before that read. A no-op when no load is in progress on this thread.
-     * </p>
-     */
-    static void touchLoadCheckpoint() {
-        Supplier<Long> checkpoint = LOAD_CHECKPOINT.get();
-        if(checkpoint != null) {
-            checkpoint.get();
-        }
-    }
-
-    /**
-     * Return the load checkpoint established for the current thread by an
-     * enclosing {@link #withLoadCheckpoint(LongSupplier, Supplier)} scope.
-     *
-     * @return the server timestamp, in microseconds, as of which the active
-     *         load reflects the database
-     * @throws IllegalStateException if no load is in progress on the current
-     *             thread
-     */
-    static long currentLoadCheckpoint() {
-        Supplier<Long> checkpoint = LOAD_CHECKPOINT.get();
-        Preconditions.checkState(checkpoint != null,
-                "No load checkpoint is established on the current thread");
-        return checkpoint.get();
-    }
-
-    /**
      * INTERNAL method to load a {@link Record} from {@code clazz} identified by
      * {@code id}.
      *
@@ -251,16 +180,19 @@ public abstract class Record implements Comparable<Record> {
      * @param id
      * @param existing
      * @param connections
+     * @param checkpoint the server timestamp, in microseconds, to checkpoint
+     *            the loaded {@link Record} at
      * @return the loaded Record
      */
     protected static <T extends Record> T load(Class<?> clazz, long id,
             ConcurrentMap<Long, Record> existing, ConnectionPool connections,
-            Runway runway, @Nullable Map<String, Set<Object>> data,
+            Runway runway, long checkpoint,
+            @Nullable Map<String, Set<Object>> data,
             @Nullable Map<Long, Map<String, Set<Object>>> targets) {
         Concourse concourse = connections.request();
         try {
             return load(clazz, id, existing, connections, concourse, runway,
-                    data, null, targets);
+                    checkpoint, data, null, targets);
         }
         finally {
             connections.release(concourse);
@@ -528,6 +460,8 @@ public abstract class Record implements Comparable<Record> {
      * @param connections the {@link ConnectionPool} to use
      * @param concourse the active {@link Concourse} connection
      * @param runway the owning {@link Runway} instance
+     * @param checkpoint the server timestamp, in microseconds, to checkpoint
+     *            the loaded {@link Record} at
      * @param data pre-loaded data for this record, or {@code null} to fetch
      *            from the database
      * @param prefix a key prefix for navigation-style nested keys, or
@@ -540,7 +474,7 @@ public abstract class Record implements Comparable<Record> {
     @SuppressWarnings("unchecked")
     private static <T extends Record> T load(Class<?> clazz, long id,
             ConcurrentMap<Long, Record> existing, ConnectionPool connections,
-            Concourse concourse, Runway runway,
+            Concourse concourse, Runway runway, long checkpoint,
             @Nullable Map<String, Set<Object>> data, String prefix,
             @Nullable Map<Long, Map<String, Set<Object>>> targets) {
         T record = (T) newDefaultInstance(clazz, connections);
@@ -548,6 +482,7 @@ public abstract class Record implements Comparable<Record> {
         setInternalFieldValue("waitingToBeDeleted", new LinkedHashSet<>(),
                 record);
         record.assign(runway);
+        record.checkpoint(checkpoint);
         record.load(concourse, existing, data, prefix, targets);
         record.onLoad();
         return record;
@@ -1661,6 +1596,7 @@ public abstract class Record implements Comparable<Record> {
         Concourse concourse = connections.request();
         try {
             ConcurrentMap<Long, Record> existing = new ConcurrentHashMap<>();
+            checkpoint(concourse.time().getMicros());
             load(concourse, existing);
             onLoad();
         }
@@ -2223,8 +2159,8 @@ public abstract class Record implements Comparable<Record> {
                                 value = existing.get(id);
                                 value = value == null
                                         ? load(type, id, existing, connections,
-                                                concourse, runway, data,
-                                                prepend, targets)
+                                                concourse, runway, checkpointTs,
+                                                data, prepend, targets)
                                         : value;
                             }
                         }
@@ -2253,9 +2189,6 @@ public abstract class Record implements Comparable<Record> {
             }
         }
         __checksum = checksum();
-        Supplier<Long> loadCheckpoint = LOAD_CHECKPOINT.get();
-        checkpoint(loadCheckpoint != null ? loadCheckpoint.get()
-                : concourse.time().getMicros());
     }
 
     /**
@@ -2731,8 +2664,8 @@ public abstract class Record implements Comparable<Record> {
                         Class<? extends Record> targetClass = Reflection
                                 .getClassCasted(section);
                         converted = load(targetClass, target, alreadyLoaded,
-                                connections, concourse, runway, data, null,
-                                targets);
+                                connections, concourse, runway, checkpointTs,
+                                data, null, targets);
                     }
                 }
             }

--- a/src/main/java/com/cinchapi/runway/Record.java
+++ b/src/main/java/com/cinchapi/runway/Record.java
@@ -180,19 +180,16 @@ public abstract class Record implements Comparable<Record> {
      * @param id
      * @param existing
      * @param connections
-     * @param checkpoint the server timestamp, in microseconds, to checkpoint
-     *            the loaded {@link Record} at
      * @return the loaded Record
      */
     protected static <T extends Record> T load(Class<?> clazz, long id,
             ConcurrentMap<Long, Record> existing, ConnectionPool connections,
-            Runway runway, long checkpoint,
-            @Nullable Map<String, Set<Object>> data,
+            Runway runway, @Nullable Map<String, Set<Object>> data,
             @Nullable Map<Long, Map<String, Set<Object>>> targets) {
         Concourse concourse = connections.request();
         try {
             return load(clazz, id, existing, connections, concourse, runway,
-                    checkpoint, data, null, targets);
+                    data, null, targets);
         }
         finally {
             connections.release(concourse);
@@ -460,8 +457,6 @@ public abstract class Record implements Comparable<Record> {
      * @param connections the {@link ConnectionPool} to use
      * @param concourse the active {@link Concourse} connection
      * @param runway the owning {@link Runway} instance
-     * @param checkpoint the server timestamp, in microseconds, to checkpoint
-     *            the loaded {@link Record} at
      * @param data pre-loaded data for this record, or {@code null} to fetch
      *            from the database
      * @param prefix a key prefix for navigation-style nested keys, or
@@ -474,7 +469,7 @@ public abstract class Record implements Comparable<Record> {
     @SuppressWarnings("unchecked")
     private static <T extends Record> T load(Class<?> clazz, long id,
             ConcurrentMap<Long, Record> existing, ConnectionPool connections,
-            Concourse concourse, Runway runway, long checkpoint,
+            Concourse concourse, Runway runway,
             @Nullable Map<String, Set<Object>> data, String prefix,
             @Nullable Map<Long, Map<String, Set<Object>>> targets) {
         T record = (T) newDefaultInstance(clazz, connections);
@@ -482,7 +477,6 @@ public abstract class Record implements Comparable<Record> {
         setInternalFieldValue("waitingToBeDeleted", new LinkedHashSet<>(),
                 record);
         record.assign(runway);
-        record.checkpoint(checkpoint);
         record.load(concourse, existing, data, prefix, targets);
         record.onLoad();
         return record;
@@ -2159,8 +2153,8 @@ public abstract class Record implements Comparable<Record> {
                                 value = existing.get(id);
                                 value = value == null
                                         ? load(type, id, existing, connections,
-                                                concourse, runway, checkpointTs,
-                                                data, prepend, targets)
+                                                concourse, runway, data,
+                                                prepend, targets)
                                         : value;
                             }
                         }
@@ -2664,8 +2658,8 @@ public abstract class Record implements Comparable<Record> {
                         Class<? extends Record> targetClass = Reflection
                                 .getClassCasted(section);
                         converted = load(targetClass, target, alreadyLoaded,
-                                connections, concourse, runway, checkpointTs,
-                                data, null, targets);
+                                connections, concourse, runway, data, null,
+                                targets);
                     }
                 }
             }

--- a/src/main/java/com/cinchapi/runway/Record.java
+++ b/src/main/java/com/cinchapi/runway/Record.java
@@ -101,6 +101,7 @@ import com.cinchapi.runway.util.ComputedEntry;
 import com.cinchapi.runway.validation.Validator;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicates;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -174,22 +175,21 @@ public abstract class Record implements Comparable<Record> {
     }
 
     /**
-     * The server timestamp, in microseconds, as of which the {@link Record}
-     * being loaded on the current thread reflects the database, or {@code null}
-     * when no load is in progress on this thread.
+     * The load checkpoint &mdash; a server timestamp, in microseconds, as of
+     * which the {@link Record Records} materialized on the current thread
+     * reflect the database &mdash; for the load in progress on this thread, or
+     * {@code null} when no load is in progress.
      */
-    private static final ThreadLocal<Long> LOAD_CHECKPOINT = new ThreadLocal<>();
+    private static final ThreadLocal<Supplier<Long>> LOAD_CHECKPOINT = new ThreadLocal<>();
 
     /**
      * Run {@code load} with {@code checkpoint} established as the load
      * checkpoint for every {@link Record} materialized on the current thread
      * while it runs.
      * <p>
-     * Re-entrant: a nested call inherits the checkpoint already in scope rather
-     * than replacing it, so an entire load &mdash; a {@link Record} and every
-     * {@link Record} linked from it &mdash; shares one checkpoint.
-     * {@code checkpoint} is evaluated only when this call establishes the
-     * scope, never when it inherits one.
+     * Re-entrant: a nested call shares the checkpoint already in scope rather
+     * than establishing a new one, so an entire load &mdash; a {@link Record}
+     * and every {@link Record} linked from it &mdash; shares one checkpoint.
      *
      * @param checkpoint supplies the server timestamp, in microseconds, as of
      *            which the load reflects the database
@@ -201,7 +201,7 @@ public abstract class Record implements Comparable<Record> {
             return load.get();
         }
         else {
-            LOAD_CHECKPOINT.set(checkpoint.getAsLong());
+            LOAD_CHECKPOINT.set(Suppliers.memoize(checkpoint::getAsLong));
             try {
                 return load.get();
             }
@@ -209,6 +209,38 @@ public abstract class Record implements Comparable<Record> {
                 LOAD_CHECKPOINT.remove();
             }
         }
+    }
+
+    /**
+     * Resolve the load checkpoint for the current thread now, if a load is in
+     * progress.
+     * <p>
+     * Call this immediately before issuing a read that materializes
+     * {@link Record Records} so the checkpoint reflects a server time at or
+     * before that read. A no-op when no load is in progress on this thread.
+     * </p>
+     */
+    static void touchLoadCheckpoint() {
+        Supplier<Long> checkpoint = LOAD_CHECKPOINT.get();
+        if(checkpoint != null) {
+            checkpoint.get();
+        }
+    }
+
+    /**
+     * Return the load checkpoint established for the current thread by an
+     * enclosing {@link #withLoadCheckpoint(LongSupplier, Supplier)} scope.
+     *
+     * @return the server timestamp, in microseconds, as of which the active
+     *         load reflects the database
+     * @throws IllegalStateException if no load is in progress on the current
+     *             thread
+     */
+    static long currentLoadCheckpoint() {
+        Supplier<Long> checkpoint = LOAD_CHECKPOINT.get();
+        Preconditions.checkState(checkpoint != null,
+                "No load checkpoint is established on the current thread");
+        return checkpoint.get();
     }
 
     /**
@@ -2221,8 +2253,8 @@ public abstract class Record implements Comparable<Record> {
             }
         }
         __checksum = checksum();
-        Long loadCheckpoint = LOAD_CHECKPOINT.get();
-        checkpoint(loadCheckpoint != null ? loadCheckpoint
+        Supplier<Long> loadCheckpoint = LOAD_CHECKPOINT.get();
+        checkpoint(loadCheckpoint != null ? loadCheckpoint.get()
                 : concourse.time().getMicros());
     }
 

--- a/src/main/java/com/cinchapi/runway/Runway.java
+++ b/src/main/java/com/cinchapi/runway/Runway.java
@@ -57,6 +57,7 @@ import com.cinchapi.concourse.Concourse;
 import com.cinchapi.concourse.ConnectionPool;
 import com.cinchapi.concourse.DuplicateEntryException;
 import com.cinchapi.concourse.Link;
+import com.cinchapi.concourse.Timestamp;
 import com.cinchapi.concourse.TransactionException;
 import com.cinchapi.concourse.lang.BuildableState;
 import com.cinchapi.concourse.lang.Criteria;
@@ -898,12 +899,14 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
                         }
                     }
                     if(saver.commit()) {
-                        long checkpoint = saver.time();
-                        seen.entrySet().stream().filter(e -> e.getValue())
-                                .map(e -> e.getKey()).forEach(record -> {
-                                    enqueueSaveNotification(record);
-                                    record.checkpoint(checkpoint);
-                                });
+                        saver.time(ts -> {
+                            long checkpoint = ts.getMicros();
+                            seen.entrySet().stream().filter(e -> e.getValue())
+                                    .map(e -> e.getKey()).forEach(record -> {
+                                        enqueueSaveNotification(record);
+                                        record.checkpoint(checkpoint);
+                                    });
+                        });
                         return true;
                     }
                     else if(attempts > MAX_SPURIOUS_SAVE_RETRIES) {
@@ -1443,9 +1446,9 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
                         read.data.then($data -> read.navigated
                                 .then($navigated -> resolveLinkTargets(
                                         sharedReader, $data, $navigated))
-                                .then($targets -> read.time
-                                        .map($ts -> instantiateAll($ts, clazz,
-                                                any, $data, $targets))))
+                                .then($targets -> read.time.map(
+                                        $ts -> instantiateAll($ts.getMicros(),
+                                                clazz, any, $data, $targets))))
                                 .onResolve(records::set);
                         sharedReader.drain();
                         return records.get();
@@ -1460,9 +1463,9 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
                 return read.data.then($data -> read.navigated
                         .then($navigated -> resolveLinkTargets(reader, $data,
                                 $navigated))
-                        .then($targets -> read.time
-                                .map($ts -> finalizeSet($ts, clazz, any, $data,
-                                        $targets, hasFilter, filter))));
+                        .then($targets -> read.time.map(
+                                $ts -> finalizeSet($ts.getMicros(), clazz, any,
+                                        $data, $targets, hasFilter, filter))));
             }
         }
         else {
@@ -1584,9 +1587,10 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
                             read.data.then($data -> read.navigated
                                     .then($navigated -> resolveLinkTargets(
                                             sharedReader, $data, $navigated))
-                                    .then($targets -> read.time.map(
-                                            $ts -> instantiateAll($ts, clazz,
-                                                    any, $data, $targets))))
+                                    .then($targets -> read.time
+                                            .map($ts -> instantiateAll(
+                                                    $ts.getMicros(), clazz, any,
+                                                    $data, $targets))))
                                     .onResolve(records::set);
                             sharedReader.drain();
                             return records.get();
@@ -1609,9 +1613,9 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
                 return read.data.then($data -> read.navigated
                         .then($navigated -> resolveLinkTargets(reader, $data,
                                 $navigated))
-                        .then($targets -> read.time
-                                .map($ts -> finalizeSet($ts, clazz, any, $data,
-                                        $targets, hasFilter, filter))));
+                        .then($targets -> read.time.map(
+                                $ts -> finalizeSet($ts.getMicros(), clazz, any,
+                                        $data, $targets, hasFilter, filter))));
             }
             else {
                 Set<T> records = any
@@ -1762,7 +1766,7 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
                 .getClassHierarchy(initialClazz).size() > 1;
         Set<String> paths = needsSectionLookup ? null
                 : getPathsForClassIfSupported(initialClazz);
-        Pending<Long> time = reader.time();
+        Pending<Timestamp> time = reader.time();
         Pending<Map<String, Set<Object>>> data = paths != null
                 ? reader.select(paths, id)
                 : reader.select(id);
@@ -1802,7 +1806,8 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
                     .then($navigated -> resolveLinkTargets(reader,
                             ImmutableMap.of(id, $data), $navigated));
             return targets.then($targets -> time.map($ts -> {
-                T record = instantiate($ts, resolvedClazz, id, $data, $targets);
+                T record = instantiate($ts.getMicros(), resolvedClazz, id,
+                        $data, $targets);
                 if(record != null && hasFilter) {
                     return new SelectResult<>(
                             filter.test(record) ? record : null, record);
@@ -2032,7 +2037,7 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
         Set<String> navigatePaths = any
                 ? getNavigatePathsForClassHierarchyIfSupported(clazz)
                 : getNavigatePathsForClassIfSupported(clazz);
-        Pending<Long> time = reader.time();
+        Pending<Timestamp> time = reader.time();
         Pending<Map<Long, Map<String, Set<Object>>>> data = read(reader, paths,
                 criteria, order, page);
         Pending<Map<Long, Map<String, Set<Object>>>> navigated = prefetchNavigate(
@@ -3111,10 +3116,10 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
         final Pending<Map<Long, Map<String, Set<Object>>>> navigated;
 
         /**
-         * A {@link Pending} of the server time, in microseconds, as of which
-         * the matching records reflect the database.
+         * A {@link Pending} of the server {@link Timestamp} as of which the
+         * matching records reflect the database.
          */
-        final Pending<Long> time;
+        final Pending<Timestamp> time;
 
         /**
          * Construct a new {@link Read}.
@@ -3126,7 +3131,7 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
          */
         Read(Pending<Map<Long, Map<String, Set<Object>>>> data,
                 Pending<Map<Long, Map<String, Set<Object>>>> navigated,
-                Pending<Long> time) {
+                Pending<Timestamp> time) {
             this.data = data;
             this.navigated = navigated;
             this.time = time;

--- a/src/main/java/com/cinchapi/runway/Runway.java
+++ b/src/main/java/com/cinchapi/runway/Runway.java
@@ -322,26 +322,45 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
             ConnectionPool connections, Runway runway,
             @Nullable Map<String, Set<Object>> data,
             @Nullable Map<Long, Map<String, Set<Object>>> targets) {
-        try {
-            return Record.load(clazz, id, loaded, connections, runway, data,
-                    targets);
-        }
-        catch (Exception e) {
-            if(e instanceof InvalidRecordException) {
-                // For consistency with Audience framework, return "null" for
-                // invalid records so that they are indistinguishable from valid
-                // Records that are not visible to an Audience.
-                return null;
+        return Record.withLoadCheckpoint(() -> serverTime(connections), () -> {
+            try {
+                return Record.load(clazz, id, loaded, connections, runway, data,
+                        targets);
             }
-            else {
-                if(e instanceof ConstraintViolationException) {
-                    // Backwards compatibility for when constraint violations
-                    // were noted via an IllegalStateException.
-                    e = new IllegalStateException(e.getMessage());
+            catch (Exception e) {
+                if(e instanceof InvalidRecordException) {
+                    // For consistency with Audience framework, return
+                    // "null" for invalid records so that they are
+                    // indistinguishable from valid Records that are not
+                    // visible to an Audience.
+                    return null;
                 }
-                runway.onLoadFailureHandler.accept(clazz, id, e);
-                throw CheckedExceptions.throwAsRuntimeException(e);
+                else {
+                    if(e instanceof ConstraintViolationException) {
+                        // Backwards compatibility for when constraint
+                        // violations were noted via an IllegalStateException.
+                        e = new IllegalStateException(e.getMessage());
+                    }
+                    runway.onLoadFailureHandler.accept(clazz, id, e);
+                    throw CheckedExceptions.throwAsRuntimeException(e);
+                }
             }
+        });
+    }
+
+    /**
+     * Return the database server's current time, in microseconds.
+     *
+     * @param connections the {@link ConnectionPool} to borrow a connection from
+     * @return the server timestamp in microseconds
+     */
+    private static long serverTime(ConnectionPool connections) {
+        Concourse concourse = connections.request();
+        try {
+            return concourse.time().getMicros();
+        }
+        finally {
+            connections.release(concourse);
         }
     }
 
@@ -2313,9 +2332,12 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
             Map<Long, Map<String, Set<Object>>> data,
             Map<Long, Map<String, Set<Object>>> targets) {
         ConcurrentMap<Long, Record> loaded = new ConcurrentHashMap<>();
+        long checkpoint = serverTime(connections);
         return LazyTransformSet.of(data.entrySet(),
-                entry -> loadWithErrorHandling(clazz, entry.getKey(), loaded,
-                        connections, this, entry.getValue(), targets));
+                entry -> Record.withLoadCheckpoint(() -> checkpoint,
+                        () -> loadWithErrorHandling(clazz, entry.getKey(),
+                                loaded, connections, this, entry.getValue(),
+                                targets)));
     }
 
     /**
@@ -2331,9 +2353,11 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
             Map<Long, Map<String, Set<Object>>> data,
             Map<Long, Map<String, Set<Object>>> targets) {
         ConcurrentMap<Long, Record> loaded = new ConcurrentHashMap<>();
+        long checkpoint = serverTime(connections);
         return LazyTransformSet.of(data.entrySet(),
-                entry -> instantiate(entry.getKey(), loaded, entry.getValue(),
-                        targets));
+                entry -> Record.withLoadCheckpoint(() -> checkpoint,
+                        () -> instantiate(entry.getKey(), loaded,
+                                entry.getValue(), targets)));
     }
 
     /**

--- a/src/main/java/com/cinchapi/runway/Runway.java
+++ b/src/main/java/com/cinchapi/runway/Runway.java
@@ -898,15 +898,14 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
                                     preventStaleWrites);
                         }
                     }
-                    if(saver.commit()) {
-                        saver.time(ts -> {
-                            long checkpoint = ts.getMicros();
-                            seen.entrySet().stream().filter(e -> e.getValue())
-                                    .map(e -> e.getKey()).forEach(record -> {
-                                        enqueueSaveNotification(record);
-                                        record.checkpoint(checkpoint);
-                                    });
-                        });
+                    Timestamp ts = saver.commit();
+                    if(ts != null) {
+                        long checkpoint = ts.getMicros();
+                        seen.entrySet().stream().filter(e -> e.getValue())
+                                .map(e -> e.getKey()).forEach(record -> {
+                                    enqueueSaveNotification(record);
+                                    record.checkpoint(checkpoint);
+                                });
                         return true;
                     }
                     else if(attempts > MAX_SPURIOUS_SAVE_RETRIES) {

--- a/src/main/java/com/cinchapi/runway/Runway.java
+++ b/src/main/java/com/cinchapi/runway/Runway.java
@@ -898,7 +898,7 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
                         }
                     }
                     if(saver.commit()) {
-                        long checkpoint = concourse.time().getMicros();
+                        long checkpoint = saver.time();
                         seen.entrySet().stream().filter(e -> e.getValue())
                                 .map(e -> e.getKey()).forEach(record -> {
                                     enqueueSaveNotification(record);

--- a/src/main/java/com/cinchapi/runway/Runway.java
+++ b/src/main/java/com/cinchapi/runway/Runway.java
@@ -1440,15 +1440,12 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
                         Read read = enqueueRead(sharedReader, any, clazz,
                                 criteria, order, $page);
                         AtomicReference<Set<T>> records = new AtomicReference<>();
-                        read.data
-                                .then($data -> read.navigated
-                                        .then($navigated -> resolveLinkTargets(
-                                                sharedReader, $data,
-                                                $navigated))
-                                        .then($targets -> read.time
-                                                .map($ts -> instantiateAll($ts,
-                                                        clazz, any, $data,
-                                                        $targets))))
+                        read.data.then($data -> read.navigated
+                                .then($navigated -> resolveLinkTargets(
+                                        sharedReader, $data, $navigated))
+                                .then($targets -> read.time
+                                        .map($ts -> instantiateAll($ts, clazz,
+                                                any, $data, $targets))))
                                 .onResolve(records::set);
                         sharedReader.drain();
                         return records.get();
@@ -1463,9 +1460,9 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
                 return read.data.then($data -> read.navigated
                         .then($navigated -> resolveLinkTargets(reader, $data,
                                 $navigated))
-                        .then($targets -> read.time.map($ts -> finalizeSet($ts,
-                                clazz, any, $data, $targets, hasFilter,
-                                filter))));
+                        .then($targets -> read.time
+                                .map($ts -> finalizeSet($ts, clazz, any, $data,
+                                        $targets, hasFilter, filter))));
             }
         }
         else {
@@ -1612,9 +1609,9 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
                 return read.data.then($data -> read.navigated
                         .then($navigated -> resolveLinkTargets(reader, $data,
                                 $navigated))
-                        .then($targets -> read.time.map($ts -> finalizeSet($ts,
-                                clazz, any, $data, $targets, hasFilter,
-                                filter))));
+                        .then($targets -> read.time
+                                .map($ts -> finalizeSet($ts, clazz, any, $data,
+                                        $targets, hasFilter, filter))));
             }
             else {
                 Set<T> records = any
@@ -1805,8 +1802,7 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
                     .then($navigated -> resolveLinkTargets(reader,
                             ImmutableMap.of(id, $data), $navigated));
             return targets.then($targets -> time.map($ts -> {
-                T record = instantiate($ts, resolvedClazz, id, $data,
-                        $targets);
+                T record = instantiate($ts, resolvedClazz, id, $data, $targets);
                 if(record != null && hasFilter) {
                     return new SelectResult<>(
                             filter.test(record) ? record : null, record);

--- a/src/main/java/com/cinchapi/runway/Runway.java
+++ b/src/main/java/com/cinchapi/runway/Runway.java
@@ -314,38 +314,38 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
      *            references
      * @param connections
      * @param runway
+     * @param checkpoint the server timestamp, in microseconds, to checkpoint
+     *            the loaded {@link Record} at
      * @param data
      * @return the loaded {@link Record} instance
      */
     private static <T extends Record> T loadWithErrorHandling(Class<T> clazz,
             long id, ConcurrentMap<Long, Record> loaded,
-            ConnectionPool connections, Runway runway,
+            ConnectionPool connections, Runway runway, long checkpoint,
             @Nullable Map<String, Set<Object>> data,
             @Nullable Map<Long, Map<String, Set<Object>>> targets) {
-        return Record.withLoadCheckpoint(() -> serverTime(connections), () -> {
-            try {
-                return Record.load(clazz, id, loaded, connections, runway, data,
-                        targets);
+        try {
+            return Record.load(clazz, id, loaded, connections, runway,
+                    checkpoint, data, targets);
+        }
+        catch (Exception e) {
+            if(e instanceof InvalidRecordException) {
+                // For consistency with Audience framework, return
+                // "null" for invalid records so that they are
+                // indistinguishable from valid Records that are not
+                // visible to an Audience.
+                return null;
             }
-            catch (Exception e) {
-                if(e instanceof InvalidRecordException) {
-                    // For consistency with Audience framework, return
-                    // "null" for invalid records so that they are
-                    // indistinguishable from valid Records that are not
-                    // visible to an Audience.
-                    return null;
+            else {
+                if(e instanceof ConstraintViolationException) {
+                    // Backwards compatibility for when constraint
+                    // violations were noted via an IllegalStateException.
+                    e = new IllegalStateException(e.getMessage());
                 }
-                else {
-                    if(e instanceof ConstraintViolationException) {
-                        // Backwards compatibility for when constraint
-                        // violations were noted via an IllegalStateException.
-                        e = new IllegalStateException(e.getMessage());
-                    }
-                    runway.onLoadFailureHandler.accept(clazz, id, e);
-                    throw CheckedExceptions.throwAsRuntimeException(e);
-                }
+                runway.onLoadFailureHandler.accept(clazz, id, e);
+                throw CheckedExceptions.throwAsRuntimeException(e);
             }
-        });
+        }
     }
 
     /**
@@ -897,12 +897,13 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
                                     preventStaleWrites);
                         }
                     }
+                    long[] checkpoint = new long[1];
+                    saver.time(ts -> checkpoint[0] = ts);
                     if(saver.commit()) {
-                        long checkpointTs = saver.commitTimestamp();
                         seen.entrySet().stream().filter(e -> e.getValue())
                                 .map(e -> e.getKey()).forEach(record -> {
                                     enqueueSaveNotification(record);
-                                    record.checkpoint(checkpointTs);
+                                    record.checkpoint(checkpoint[0]);
                                 });
                         return true;
                     }
@@ -1019,8 +1020,7 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
             Map<Long, Map<String, Set<Object>>> targets = prefetchLinkTargets(
                     getNavigatePathsForClassHierarchyIfSupported(clazz), ids,
                     data);
-            return Record.withLoadCheckpoint(() -> checkpoint,
-                    () -> instantiateAll(clazz, data, targets));
+            return instantiateAll(checkpoint, clazz, data, targets);
         }
     }
 
@@ -1059,26 +1059,12 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
             Map<Long, Map<String, Set<Object>>> targets = prefetchLinkTargets(
                     getNavigatePathsForClassHierarchyIfSupported(clazz), ids,
                     data);
-            return Record.withLoadCheckpoint(() -> checkpoint,
-                    () -> instantiateAll(data, targets));
+            return instantiateAll(checkpoint, data, targets);
         }
     }
 
     @Override
     public Selections select(Selection<?>... options) {
-        return Record.withLoadCheckpoint(() -> serverTime(connections),
-                () -> $select(options));
-    }
-
-    /**
-     * Resolve every {@link Selection} in {@code options} against the database,
-     * populating each with its result.
-     *
-     * @param options the {@link Selection Selections} to resolve; must contain
-     *            at least one
-     * @return a {@link Selections} over the resolved {@code options}
-     */
-    private Selections $select(Selection<?>... options) {
         Preconditions.checkArgument(options.length > 0);
         DatabaseSelection<?>[] selections = Arrays.stream(options)
                 .peek(option -> Preconditions.checkState(
@@ -1349,8 +1335,7 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
      */
     <T extends Record> T load(long id) {
         long checkpoint = serverTime(connections);
-        return Record.withLoadCheckpoint(() -> checkpoint,
-                () -> instantiate(id, null, null));
+        return instantiate(checkpoint, id, null, null);
     }
 
     /**
@@ -1461,8 +1446,10 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
                                         .then($navigated -> resolveLinkTargets(
                                                 sharedReader, $data,
                                                 $navigated))
-                                        .map($targets -> instantiateAll(clazz,
-                                                any, $data, $targets)))
+                                        .then($targets -> read.time
+                                                .map($ts -> instantiateAll($ts,
+                                                        clazz, any, $data,
+                                                        $targets))))
                                 .onResolve(records::set);
                         sharedReader.drain();
                         return records.get();
@@ -1477,8 +1464,9 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
                 return read.data.then($data -> read.navigated
                         .then($navigated -> resolveLinkTargets(reader, $data,
                                 $navigated))
-                        .map($targets -> finalizeSet(clazz, any, $data,
-                                $targets, hasFilter, filter)));
+                        .then($targets -> read.time.map($ts -> finalizeSet($ts,
+                                clazz, any, $data, $targets, hasFilter,
+                                filter))));
             }
         }
         else {
@@ -1600,8 +1588,9 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
                             read.data.then($data -> read.navigated
                                     .then($navigated -> resolveLinkTargets(
                                             sharedReader, $data, $navigated))
-                                    .map($targets -> instantiateAll(clazz, any,
-                                            $data, $targets)))
+                                    .then($targets -> read.time.map(
+                                            $ts -> instantiateAll($ts, clazz,
+                                                    any, $data, $targets))))
                                     .onResolve(records::set);
                             sharedReader.drain();
                             return records.get();
@@ -1624,8 +1613,9 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
                 return read.data.then($data -> read.navigated
                         .then($navigated -> resolveLinkTargets(reader, $data,
                                 $navigated))
-                        .map($targets -> finalizeSet(clazz, any, $data,
-                                $targets, hasFilter, filter)));
+                        .then($targets -> read.time.map($ts -> finalizeSet($ts,
+                                clazz, any, $data, $targets, hasFilter,
+                                filter))));
             }
             else {
                 Set<T> records = any
@@ -1776,8 +1766,7 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
                 .getClassHierarchy(initialClazz).size() > 1;
         Set<String> paths = needsSectionLookup ? null
                 : getPathsForClassIfSupported(initialClazz);
-        // Resolve the checkpoint before this record read is issued.
-        Record.touchLoadCheckpoint();
+        Pending<Long> time = reader.time();
         Pending<Map<String, Set<Object>>> data = paths != null
                 ? reader.select(paths, id)
                 : reader.select(id);
@@ -1816,14 +1805,15 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
             Pending<Map<Long, Map<String, Set<Object>>>> targets = navigated
                     .then($navigated -> resolveLinkTargets(reader,
                             ImmutableMap.of(id, $data), $navigated));
-            return targets.map($targets -> {
-                T record = instantiate(resolvedClazz, id, $data, $targets);
+            return targets.then($targets -> time.map($ts -> {
+                T record = instantiate($ts, resolvedClazz, id, $data,
+                        $targets);
                 if(record != null && hasFilter) {
                     return new SelectResult<>(
                             filter.test(record) ? record : null, record);
                 }
                 return new SelectResult<>(record);
-            });
+            }));
         });
     }
 
@@ -1957,6 +1947,7 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
     private void demux(Reader reader, DatabaseSelection<?> selection,
             Map<Long, Map<String, Set<Object>>> data) {
         Object result = null;
+        long checkpoint = serverTime(connections);
         if(selection instanceof LoadRecordSelection) {
             long id = ((LoadRecordSelection<?>) selection).id;
             Map<String, Set<Object>> recordData = data.get(id);
@@ -1966,7 +1957,8 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
                     String section = (String) Iterables.getLast(sections);
                     Class actualClass = Reflection.getClassCasted(section);
                     if(selection.clazz.isAssignableFrom(actualClass)) {
-                        result = instantiate(actualClass, id, recordData, null);
+                        result = instantiate(checkpoint, actualClass, id,
+                                recordData, null);
                     }
                 }
             }
@@ -2005,8 +1997,9 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
             navigated
                     .then($navigated -> resolveLinkTargets(reader, filtered,
                             $navigated))
-                    .map($targets -> instantiateAll((Class) selection.clazz,
-                            selection.any, filtered, $targets))
+                    .map($targets -> instantiateAll(checkpoint,
+                            (Class) selection.clazz, selection.any, filtered,
+                            $targets))
                     .onResolve(resolved::set);
             reader.drain();
             result = resolved.get();
@@ -2044,11 +2037,12 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
         Set<String> navigatePaths = any
                 ? getNavigatePathsForClassHierarchyIfSupported(clazz)
                 : getNavigatePathsForClassIfSupported(clazz);
+        Pending<Long> time = reader.time();
         Pending<Map<Long, Map<String, Set<Object>>>> data = read(reader, paths,
                 criteria, order, page);
         Pending<Map<Long, Map<String, Set<Object>>>> navigated = prefetchNavigate(
                 reader, navigatePaths, criteria, page, data);
-        return new Read(data, navigated);
+        return new Read(data, navigated, time);
     }
 
     /**
@@ -2165,6 +2159,8 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
      * and pre-fetched {@code targets}, applying {@code filter} when
      * {@code hasFilter} is {@code true}.
      *
+     * @param checkpoint the server timestamp, in microseconds, to checkpoint
+     *            the loaded {@link Record Records} at
      * @param clazz the target {@link Record} class
      * @param any whether to query across the class hierarchy
      * @param data the matching record data
@@ -2175,11 +2171,12 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
      * @param <T> the {@link Record} type
      * @return the {@link SelectResult}
      */
-    private <T extends Record> SelectResult<Set<T>> finalizeSet(Class<T> clazz,
-            boolean any, Map<Long, Map<String, Set<Object>>> data,
+    private <T extends Record> SelectResult<Set<T>> finalizeSet(long checkpoint,
+            Class<T> clazz, boolean any,
+            Map<Long, Map<String, Set<Object>>> data,
             Map<Long, Map<String, Set<Object>>> targets, boolean hasFilter,
             Predicate<T> filter) {
-        Set<T> records = instantiateAll(clazz, any, data, targets);
+        Set<T> records = instantiateAll(checkpoint, clazz, any, data, targets);
         if(hasFilter) {
             return new SelectResult<>(
                     records.stream().filter(filter).collect(
@@ -2248,17 +2245,18 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
      * that is contained within the specified {@code clazz} and has the
      * specified {@code id}.
      *
+     * @param checkpoint
      * @param clazz
      * @param id
      * @param existing
      * @param data
      * @return the loaded {@link Record} instance
      */
-    private <T extends Record> T instantiate(Class<T> clazz, long id,
-            @Nullable Map<String, Set<Object>> data,
+    private <T extends Record> T instantiate(long checkpoint, Class<T> clazz,
+            long id, @Nullable Map<String, Set<Object>> data,
             @Nullable Map<Long, Map<String, Set<Object>>> targets) {
         return loadWithErrorHandling(clazz, id, new ConcurrentHashMap<>(),
-                connections, this, data, targets);
+                connections, this, checkpoint, data, targets);
     }
 
     /**
@@ -2272,13 +2270,14 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
      * {@link Record}.
      * </p>
      *
+     * @param checkpoint
      * @param id
      * @param loaded
      * @param existing
      * @param data
      * @return the loaded {@link Record} instance
      */
-    private <T extends Record> T instantiate(long id,
+    private <T extends Record> T instantiate(long checkpoint, long id,
             ConcurrentMap<Long, Record> loaded,
             @Nullable Map<String, Set<Object>> data,
             @Nullable Map<Long, Map<String, Set<Object>>> targets) {
@@ -2296,8 +2295,8 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
         String section = (String) Iterables
                 .getLast(data.get(Record.SECTION_KEY));
         Class<T> clazz = Reflection.getClassCasted(section);
-        return loadWithErrorHandling(clazz, id, loaded, connections, this, data,
-                targets);
+        return loadWithErrorHandling(clazz, id, loaded, connections, this,
+                checkpoint, data, targets);
     }
 
     /**
@@ -2311,15 +2310,17 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
      * {@link Record}.
      * </p>
      *
+     * @param checkpoint
      * @param id
      * @param existing
      * @param data
      * @return the loaded {@link Record} instance
      */
-    private <T extends Record> T instantiate(long id,
+    private <T extends Record> T instantiate(long checkpoint, long id,
             @Nullable Map<String, Set<Object>> data,
             @Nullable Map<Long, Map<String, Set<Object>>> targets) {
-        return instantiate(id, new ConcurrentHashMap<>(), data, targets);
+        return instantiate(checkpoint, id, new ConcurrentHashMap<>(), data,
+                targets);
     }
 
     /**
@@ -2327,6 +2328,8 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
      * across {@code clazz}'s hierarchy when {@code any} is {@code true} or as
      * exact instances of {@code clazz} otherwise.
      *
+     * @param checkpoint the server timestamp, in microseconds, to checkpoint
+     *            the loaded {@link Record Records} at
      * @param clazz the target {@link Record} class
      * @param any whether to instantiate across the class hierarchy
      * @param data the record data keyed by record id
@@ -2334,59 +2337,54 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
      *            record id
      * @return the instantiated {@link Record Records}
      */
-    private <T extends Record> Set<T> instantiateAll(Class<T> clazz,
-            boolean any, Map<Long, Map<String, Set<Object>>> data,
+    private <T extends Record> Set<T> instantiateAll(long checkpoint,
+            Class<T> clazz, boolean any,
+            Map<Long, Map<String, Set<Object>>> data,
             Map<Long, Map<String, Set<Object>>> targets) {
-        return any ? instantiateAll(data, targets)
-                : instantiateAll(clazz, data, targets);
+        return any ? instantiateAll(checkpoint, data, targets)
+                : instantiateAll(checkpoint, clazz, data, targets);
     }
 
     /**
      * Create a {@link Record} instance of type {@code clazz} (or one of its
      * descendants) for each entry in {@code data}.
      *
+     * @param checkpoint the server timestamp, in microseconds, to checkpoint
+     *            the loaded {@link Record Records} at
      * @param clazz the target {@link Record} class
      * @param data the record data keyed by record id
      * @param targets the pre-fetched {@link Link} targets keyed by destination
      *            record id
      * @return the instantiated {@link Record Records}
      */
-    private <T extends Record> Set<T> instantiateAll(Class<T> clazz,
-            Map<Long, Map<String, Set<Object>>> data,
+    private <T extends Record> Set<T> instantiateAll(long checkpoint,
+            Class<T> clazz, Map<Long, Map<String, Set<Object>>> data,
             Map<Long, Map<String, Set<Object>>> targets) {
         ConcurrentMap<Long, Record> loaded = new ConcurrentHashMap<>();
-        // NOTE: Use the enclosing scope's checkpoint, not a fresh reading;
-        // the data was fetched earlier, so a new timestamp would post-date
-        // the read and could miss a concurrent write.
-        long checkpoint = Record.currentLoadCheckpoint();
         return LazyTransformSet.of(data.entrySet(),
-                entry -> Record.withLoadCheckpoint(() -> checkpoint,
-                        () -> loadWithErrorHandling(clazz, entry.getKey(),
-                                loaded, connections, this, entry.getValue(),
-                                targets)));
+                entry -> loadWithErrorHandling(clazz, entry.getKey(), loaded,
+                        connections, this, checkpoint, entry.getValue(),
+                        targets));
     }
 
     /**
      * Create a {@link Record} instance for each entry in {@code data}, with
      * each record's class determined by its stored section key.
      *
+     * @param checkpoint the server timestamp, in microseconds, to checkpoint
+     *            the loaded {@link Record Records} at
      * @param data the record data keyed by record id
      * @param targets the pre-fetched {@link Link} targets keyed by destination
      *            record id
      * @return the instantiated {@link Record Records}
      */
-    private <T extends Record> Set<T> instantiateAll(
+    private <T extends Record> Set<T> instantiateAll(long checkpoint,
             Map<Long, Map<String, Set<Object>>> data,
             Map<Long, Map<String, Set<Object>>> targets) {
         ConcurrentMap<Long, Record> loaded = new ConcurrentHashMap<>();
-        // NOTE: Use the enclosing scope's checkpoint, not a fresh reading;
-        // the data was fetched earlier, so a new timestamp would post-date
-        // the read and could miss a concurrent write.
-        long checkpoint = Record.currentLoadCheckpoint();
         return LazyTransformSet.of(data.entrySet(),
-                entry -> Record.withLoadCheckpoint(() -> checkpoint,
-                        () -> instantiate(entry.getKey(), loaded,
-                                entry.getValue(), targets)));
+                entry -> instantiate(checkpoint, entry.getKey(), loaded,
+                        entry.getValue(), targets));
     }
 
     /**
@@ -2513,8 +2511,6 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
     private Pending<Map<Long, Map<String, Set<Object>>>> read(Reader reader,
             @Nullable Set<String> paths, Criteria criteria,
             @Nullable Order order, @Nullable Page page) {
-        // Resolve the checkpoint before this record read is issued.
-        Record.touchLoadCheckpoint();
         if(order != null && page != null) {
             return paths != null ? reader.select(paths, criteria, order, page)
                     : reader.select(criteria, order, page);
@@ -3120,16 +3116,25 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
         final Pending<Map<Long, Map<String, Set<Object>>>> navigated;
 
         /**
+         * A {@link Pending} of the server time, in microseconds, as of which
+         * the matching records reflect the database.
+         */
+        final Pending<Long> time;
+
+        /**
          * Construct a new {@link Read}.
          *
          * @param data a {@link Pending} of the matching records' data
          * @param navigated a {@link Pending} of the {@code navigate()}
          *            pre-fetch
+         * @param time a {@link Pending} of the server time the records reflect
          */
         Read(Pending<Map<Long, Map<String, Set<Object>>>> data,
-                Pending<Map<Long, Map<String, Set<Object>>>> navigated) {
+                Pending<Map<Long, Map<String, Set<Object>>>> navigated,
+                Pending<Long> time) {
             this.data = data;
             this.navigated = navigated;
+            this.time = time;
         }
 
     }

--- a/src/main/java/com/cinchapi/runway/Runway.java
+++ b/src/main/java/com/cinchapi/runway/Runway.java
@@ -879,7 +879,7 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
                         }
                     }
                     if(saver.commit()) {
-                        long checkpointTs = concourse.time().getMicros();
+                        long checkpointTs = saver.commitTimestamp();
                         seen.entrySet().stream().filter(e -> e.getValue())
                                 .map(e -> e.getKey()).forEach(record -> {
                                     enqueueSaveNotification(record);

--- a/src/main/java/com/cinchapi/runway/Runway.java
+++ b/src/main/java/com/cinchapi/runway/Runway.java
@@ -315,19 +315,17 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
      *            references
      * @param connections
      * @param runway
-     * @param checkpoint the server timestamp, in microseconds, to checkpoint
-     *            the loaded {@link Record} at
      * @param data
      * @return the loaded {@link Record} instance
      */
     private static <T extends Record> T loadWithErrorHandling(Class<T> clazz,
             long id, ConcurrentMap<Long, Record> loaded,
-            ConnectionPool connections, Runway runway, long checkpoint,
+            ConnectionPool connections, Runway runway,
             @Nullable Map<String, Set<Object>> data,
             @Nullable Map<Long, Map<String, Set<Object>>> targets) {
         try {
-            return Record.load(clazz, id, loaded, connections, runway,
-                    checkpoint, data, targets);
+            return Record.load(clazz, id, loaded, connections, runway, data,
+                    targets);
         }
         catch (Exception e) {
             if(e instanceof InvalidRecordException) {
@@ -2254,8 +2252,11 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
     private <T extends Record> T instantiate(long checkpoint, Class<T> clazz,
             long id, @Nullable Map<String, Set<Object>> data,
             @Nullable Map<Long, Map<String, Set<Object>>> targets) {
-        return loadWithErrorHandling(clazz, id, new ConcurrentHashMap<>(),
-                connections, this, checkpoint, data, targets);
+        ConcurrentMap<Long, Record> loaded = new ConcurrentHashMap<>();
+        T record = loadWithErrorHandling(clazz, id, loaded, connections, this,
+                data, targets);
+        loaded.values().forEach(r -> r.checkpoint(checkpoint));
+        return record;
     }
 
     /**
@@ -2276,7 +2277,7 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
      * @param data
      * @return the loaded {@link Record} instance
      */
-    private <T extends Record> T instantiate(long checkpoint, long id,
+    private <T extends Record> T instantiate(long id,
             ConcurrentMap<Long, Record> loaded,
             @Nullable Map<String, Set<Object>> data,
             @Nullable Map<Long, Map<String, Set<Object>>> targets) {
@@ -2294,8 +2295,8 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
         String section = (String) Iterables
                 .getLast(data.get(Record.SECTION_KEY));
         Class<T> clazz = Reflection.getClassCasted(section);
-        return loadWithErrorHandling(clazz, id, loaded, connections, this,
-                checkpoint, data, targets);
+        return loadWithErrorHandling(clazz, id, loaded, connections, this, data,
+                targets);
     }
 
     /**
@@ -2318,8 +2319,10 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
     private <T extends Record> T instantiate(long checkpoint, long id,
             @Nullable Map<String, Set<Object>> data,
             @Nullable Map<Long, Map<String, Set<Object>>> targets) {
-        return instantiate(checkpoint, id, new ConcurrentHashMap<>(), data,
-                targets);
+        ConcurrentMap<Long, Record> loaded = new ConcurrentHashMap<>();
+        T record = instantiate(id, loaded, data, targets);
+        loaded.values().forEach(r -> r.checkpoint(checkpoint));
+        return record;
     }
 
     /**
@@ -2360,10 +2363,17 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
             Class<T> clazz, Map<Long, Map<String, Set<Object>>> data,
             Map<Long, Map<String, Set<Object>>> targets) {
         ConcurrentMap<Long, Record> loaded = new ConcurrentHashMap<>();
-        return LazyTransformSet.of(data.entrySet(),
-                entry -> loadWithErrorHandling(clazz, entry.getKey(), loaded,
-                        connections, this, checkpoint, entry.getValue(),
-                        targets));
+        Set<Long> stamped = ConcurrentHashMap.newKeySet();
+        return LazyTransformSet.of(data.entrySet(), entry -> {
+            T record = loadWithErrorHandling(clazz, entry.getKey(), loaded,
+                    connections, this, entry.getValue(), targets);
+            loaded.forEach((id, r) -> {
+                if(stamped.add(id)) {
+                    r.checkpoint(checkpoint);
+                }
+            });
+            return record;
+        });
     }
 
     /**
@@ -2381,9 +2391,17 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
             Map<Long, Map<String, Set<Object>>> data,
             Map<Long, Map<String, Set<Object>>> targets) {
         ConcurrentMap<Long, Record> loaded = new ConcurrentHashMap<>();
-        return LazyTransformSet.of(data.entrySet(),
-                entry -> instantiate(checkpoint, entry.getKey(), loaded,
-                        entry.getValue(), targets));
+        Set<Long> stamped = ConcurrentHashMap.newKeySet();
+        return LazyTransformSet.of(data.entrySet(), entry -> {
+            T record = instantiate(entry.getKey(), loaded, entry.getValue(),
+                    targets);
+            loaded.forEach((id, r) -> {
+                if(stamped.add(id)) {
+                    r.checkpoint(checkpoint);
+                }
+            });
+            return record;
+        });
     }
 
     /**

--- a/src/main/java/com/cinchapi/runway/Runway.java
+++ b/src/main/java/com/cinchapi/runway/Runway.java
@@ -897,13 +897,12 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
                                     preventStaleWrites);
                         }
                     }
-                    long[] checkpoint = new long[1];
-                    saver.time(ts -> checkpoint[0] = ts);
                     if(saver.commit()) {
+                        long checkpoint = concourse.time().getMicros();
                         seen.entrySet().stream().filter(e -> e.getValue())
                                 .map(e -> e.getKey()).forEach(record -> {
                                     enqueueSaveNotification(record);
-                                    record.checkpoint(checkpoint[0]);
+                                    record.checkpoint(checkpoint);
                                 });
                         return true;
                     }

--- a/src/main/java/com/cinchapi/runway/Runway.java
+++ b/src/main/java/com/cinchapi/runway/Runway.java
@@ -1002,6 +1002,8 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
             return find(clazz, $Criteria.search(query, keys));
         }
         else {
+            // Capture before the fetch so the checkpoint precedes the read.
+            long checkpoint = serverTime(connections);
             Set<Long> ids;
             Map<Long, Map<String, Set<Object>>> data;
             Set<String> paths = getPathsForClassHierarchyIfSupported(clazz);
@@ -1017,7 +1019,8 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
             Map<Long, Map<String, Set<Object>>> targets = prefetchLinkTargets(
                     getNavigatePathsForClassHierarchyIfSupported(clazz), ids,
                     data);
-            return instantiateAll(clazz, data, targets);
+            return Record.withLoadCheckpoint(() -> checkpoint,
+                    () -> instantiateAll(clazz, data, targets));
         }
     }
 
@@ -1039,6 +1042,8 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
             return findAny(clazz, $Criteria.search(query, keys));
         }
         else {
+            // Capture before the fetch so the checkpoint precedes the read.
+            long checkpoint = serverTime(connections);
             Set<Long> ids;
             Map<Long, Map<String, Set<Object>>> data;
             Set<String> paths = getPathsForClassHierarchyIfSupported(clazz);
@@ -1054,12 +1059,26 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
             Map<Long, Map<String, Set<Object>>> targets = prefetchLinkTargets(
                     getNavigatePathsForClassHierarchyIfSupported(clazz), ids,
                     data);
-            return instantiateAll(data, targets);
+            return Record.withLoadCheckpoint(() -> checkpoint,
+                    () -> instantiateAll(data, targets));
         }
     }
 
     @Override
     public Selections select(Selection<?>... options) {
+        return Record.withLoadCheckpoint(() -> serverTime(connections),
+                () -> $select(options));
+    }
+
+    /**
+     * Resolve every {@link Selection} in {@code options} against the database,
+     * populating each with its result.
+     *
+     * @param options the {@link Selection Selections} to resolve; must contain
+     *            at least one
+     * @return a {@link Selections} over the resolved {@code options}
+     */
+    private Selections $select(Selection<?>... options) {
         Preconditions.checkArgument(options.length > 0);
         DatabaseSelection<?>[] selections = Arrays.stream(options)
                 .peek(option -> Preconditions.checkState(
@@ -1329,7 +1348,9 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
      * @return the loaded record
      */
     <T extends Record> T load(long id) {
-        return instantiate(id, null, null);
+        long checkpoint = serverTime(connections);
+        return Record.withLoadCheckpoint(() -> checkpoint,
+                () -> instantiate(id, null, null));
     }
 
     /**
@@ -1755,6 +1776,8 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
                 .getClassHierarchy(initialClazz).size() > 1;
         Set<String> paths = needsSectionLookup ? null
                 : getPathsForClassIfSupported(initialClazz);
+        // Resolve the checkpoint before this record read is issued.
+        Record.touchLoadCheckpoint();
         Pending<Map<String, Set<Object>>> data = paths != null
                 ? reader.select(paths, id)
                 : reader.select(id);
@@ -2332,7 +2355,10 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
             Map<Long, Map<String, Set<Object>>> data,
             Map<Long, Map<String, Set<Object>>> targets) {
         ConcurrentMap<Long, Record> loaded = new ConcurrentHashMap<>();
-        long checkpoint = serverTime(connections);
+        // NOTE: Use the enclosing scope's checkpoint, not a fresh reading;
+        // the data was fetched earlier, so a new timestamp would post-date
+        // the read and could miss a concurrent write.
+        long checkpoint = Record.currentLoadCheckpoint();
         return LazyTransformSet.of(data.entrySet(),
                 entry -> Record.withLoadCheckpoint(() -> checkpoint,
                         () -> loadWithErrorHandling(clazz, entry.getKey(),
@@ -2353,7 +2379,10 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
             Map<Long, Map<String, Set<Object>>> data,
             Map<Long, Map<String, Set<Object>>> targets) {
         ConcurrentMap<Long, Record> loaded = new ConcurrentHashMap<>();
-        long checkpoint = serverTime(connections);
+        // NOTE: Use the enclosing scope's checkpoint, not a fresh reading;
+        // the data was fetched earlier, so a new timestamp would post-date
+        // the read and could miss a concurrent write.
+        long checkpoint = Record.currentLoadCheckpoint();
         return LazyTransformSet.of(data.entrySet(),
                 entry -> Record.withLoadCheckpoint(() -> checkpoint,
                         () -> instantiate(entry.getKey(), loaded,
@@ -2484,6 +2513,8 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
     private Pending<Map<Long, Map<String, Set<Object>>>> read(Reader reader,
             @Nullable Set<String> paths, Criteria criteria,
             @Nullable Order order, @Nullable Page page) {
+        // Resolve the checkpoint before this record read is issued.
+        Record.touchLoadCheckpoint();
         if(order != null && page != null) {
             return paths != null ? reader.select(paths, criteria, order, page)
                     : reader.select(criteria, order, page);

--- a/src/main/java/com/cinchapi/runway/db/BatchReader.java
+++ b/src/main/java/com/cinchapi/runway/db/BatchReader.java
@@ -24,6 +24,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 
 import com.cinchapi.concourse.Concourse;
 import com.cinchapi.concourse.ConnectionPool;
+import com.cinchapi.concourse.Timestamp;
 import com.cinchapi.concourse.lang.CommandGroup;
 import com.cinchapi.concourse.lang.Criteria;
 import com.cinchapi.concourse.lang.paginate.Page;
@@ -258,6 +259,16 @@ public final class BatchReader extends AbstractReader {
         return Pending.deferred(this,
                 () -> ((Number) batch.flush(concourse()).get(slot))
                         .longValue());
+    }
+
+    @Override
+    public Pending<Long> time() {
+        Batch batch = batch();
+        int slot = batch.size();
+        batch.group.time();
+        return Pending.deferred(this,
+                () -> ((Timestamp) batch.flush(concourse()).get(slot))
+                        .getMicros());
     }
 
     @Override

--- a/src/main/java/com/cinchapi/runway/db/BatchReader.java
+++ b/src/main/java/com/cinchapi/runway/db/BatchReader.java
@@ -67,18 +67,6 @@ public final class BatchReader extends AbstractReader {
     private Batch current;
 
     /**
-     * Construct a {@link BatchReader} that borrows a {@link Concourse}
-     * connection from {@code pool} and returns it to {@code pool} on
-     * {@link #close()}.
-     *
-     * @param pool the {@link ConnectionPool} that owns the {@link Concourse}
-     *            connection; must not be {@code null}
-     */
-    public BatchReader(ConnectionPool pool) {
-        super(pool);
-    }
-
-    /**
      * Construct a {@link BatchReader} that submits against {@code connection}.
      * The caller retains ownership of the connection lifecycle;
      * {@link #close()} does <strong>not</strong> close it.
@@ -90,75 +78,68 @@ public final class BatchReader extends AbstractReader {
         super(connection);
     }
 
+    /**
+     * Construct a {@link BatchReader} that borrows a {@link Concourse}
+     * connection from {@code pool} and returns it to {@code pool} on
+     * {@link #close()}.
+     *
+     * @param pool the {@link ConnectionPool} that owns the {@link Concourse}
+     *            connection; must not be {@code null}
+     */
+    public BatchReader(ConnectionPool pool) {
+        super(pool);
+    }
+
     @Override
-    public Pending<Map<Long, Map<String, Set<Object>>>> select(
-            Criteria criteria) {
+    public Pending<Long> count(String key, Criteria criteria) {
         Batch batch = batch();
         int slot = batch.size();
-        batch.group.select(criteria);
+        batch.group.count(key, criteria);
+        return Pending.deferred(this,
+                () -> ((Number) batch.flush(concourse()).get(slot))
+                        .longValue());
+    }
+
+    @Override
+    public Pending<Set<Long>> find(Criteria criteria) {
+        Batch batch = batch();
+        int slot = batch.size();
+        batch.group.find(criteria);
+        return Pending.deferred(this, () -> ids(batch, slot));
+    }
+
+    @Override
+    public Pending<Object> get(String key, long record) {
+        Batch batch = batch();
+        int slot = batch.size();
+        batch.group.get(key, record);
+        return Pending.deferred(this, () -> batch.flush(concourse()).get(slot));
+    }
+
+    @Override
+    public Pending<Map<Long, Map<String, Set<Object>>>> navigate(
+            Set<String> keys, Collection<Long> records) {
+        Batch batch = batch();
+        int slot = batch.size();
+        batch.group.navigate(ImmutableList.copyOf(keys), records);
         return Pending.deferred(this, () -> mapByRecord(batch, slot));
     }
 
     @Override
-    public Pending<Map<Long, Map<String, Set<Object>>>> select(Set<String> keys,
-            Criteria criteria) {
+    public Pending<Map<Long, Map<String, Set<Object>>>> navigate(
+            Set<String> keys, Criteria criteria) {
         Batch batch = batch();
         int slot = batch.size();
-        batch.group.select(ImmutableList.copyOf(keys), criteria);
+        batch.group.navigate(ImmutableList.copyOf(keys), criteria);
         return Pending.deferred(this, () -> mapByRecord(batch, slot));
     }
 
     @Override
-    public Pending<Map<Long, Map<String, Set<Object>>>> select(
-            Criteria criteria, Order order) {
+    public Pending<Map<Long, Map<String, Set<Object>>>> navigate(
+            Set<String> keys, long record) {
         Batch batch = batch();
         int slot = batch.size();
-        batch.group.select(criteria, order);
-        return Pending.deferred(this, () -> mapByRecord(batch, slot));
-    }
-
-    @Override
-    public Pending<Map<Long, Map<String, Set<Object>>>> select(Set<String> keys,
-            Criteria criteria, Order order) {
-        Batch batch = batch();
-        int slot = batch.size();
-        batch.group.select(ImmutableList.copyOf(keys), criteria, order);
-        return Pending.deferred(this, () -> mapByRecord(batch, slot));
-    }
-
-    @Override
-    public Pending<Map<Long, Map<String, Set<Object>>>> select(
-            Criteria criteria, Page page) {
-        Batch batch = batch();
-        int slot = batch.size();
-        batch.group.select(criteria, page);
-        return Pending.deferred(this, () -> mapByRecord(batch, slot));
-    }
-
-    @Override
-    public Pending<Map<Long, Map<String, Set<Object>>>> select(Set<String> keys,
-            Criteria criteria, Page page) {
-        Batch batch = batch();
-        int slot = batch.size();
-        batch.group.select(ImmutableList.copyOf(keys), criteria, page);
-        return Pending.deferred(this, () -> mapByRecord(batch, slot));
-    }
-
-    @Override
-    public Pending<Map<Long, Map<String, Set<Object>>>> select(
-            Criteria criteria, Order order, Page page) {
-        Batch batch = batch();
-        int slot = batch.size();
-        batch.group.select(criteria, order, page);
-        return Pending.deferred(this, () -> mapByRecord(batch, slot));
-    }
-
-    @Override
-    public Pending<Map<Long, Map<String, Set<Object>>>> select(Set<String> keys,
-            Criteria criteria, Order order, Page page) {
-        Batch batch = batch();
-        int slot = batch.size();
-        batch.group.select(ImmutableList.copyOf(keys), criteria, order, page);
+        batch.group.navigate(ImmutableList.copyOf(keys), record);
         return Pending.deferred(this, () -> mapByRecord(batch, slot));
     }
 
@@ -184,11 +165,83 @@ public final class BatchReader extends AbstractReader {
     }
 
     @Override
+    public Pending<Map<Long, Map<String, Set<Object>>>> select(
+            Criteria criteria) {
+        Batch batch = batch();
+        int slot = batch.size();
+        batch.group.select(criteria);
+        return Pending.deferred(this, () -> mapByRecord(batch, slot));
+    }
+
+    @Override
+    public Pending<Map<Long, Map<String, Set<Object>>>> select(
+            Criteria criteria, Order order) {
+        Batch batch = batch();
+        int slot = batch.size();
+        batch.group.select(criteria, order);
+        return Pending.deferred(this, () -> mapByRecord(batch, slot));
+    }
+
+    @Override
+    public Pending<Map<Long, Map<String, Set<Object>>>> select(
+            Criteria criteria, Order order, Page page) {
+        Batch batch = batch();
+        int slot = batch.size();
+        batch.group.select(criteria, order, page);
+        return Pending.deferred(this, () -> mapByRecord(batch, slot));
+    }
+
+    @Override
+    public Pending<Map<Long, Map<String, Set<Object>>>> select(
+            Criteria criteria, Page page) {
+        Batch batch = batch();
+        int slot = batch.size();
+        batch.group.select(criteria, page);
+        return Pending.deferred(this, () -> mapByRecord(batch, slot));
+    }
+
+    @Override
     public Pending<Map<String, Set<Object>>> select(long record) {
         Batch batch = batch();
         int slot = batch.size();
         batch.group.select(record);
         return Pending.deferred(this, () -> recordData(batch, slot));
+    }
+
+    @Override
+    public Pending<Map<Long, Map<String, Set<Object>>>> select(Set<String> keys,
+            Criteria criteria) {
+        Batch batch = batch();
+        int slot = batch.size();
+        batch.group.select(ImmutableList.copyOf(keys), criteria);
+        return Pending.deferred(this, () -> mapByRecord(batch, slot));
+    }
+
+    @Override
+    public Pending<Map<Long, Map<String, Set<Object>>>> select(Set<String> keys,
+            Criteria criteria, Order order) {
+        Batch batch = batch();
+        int slot = batch.size();
+        batch.group.select(ImmutableList.copyOf(keys), criteria, order);
+        return Pending.deferred(this, () -> mapByRecord(batch, slot));
+    }
+
+    @Override
+    public Pending<Map<Long, Map<String, Set<Object>>>> select(Set<String> keys,
+            Criteria criteria, Order order, Page page) {
+        Batch batch = batch();
+        int slot = batch.size();
+        batch.group.select(ImmutableList.copyOf(keys), criteria, order, page);
+        return Pending.deferred(this, () -> mapByRecord(batch, slot));
+    }
+
+    @Override
+    public Pending<Map<Long, Map<String, Set<Object>>>> select(Set<String> keys,
+            Criteria criteria, Page page) {
+        Batch batch = batch();
+        int slot = batch.size();
+        batch.group.select(ImmutableList.copyOf(keys), criteria, page);
+        return Pending.deferred(this, () -> mapByRecord(batch, slot));
     }
 
     @Override
@@ -209,66 +262,12 @@ public final class BatchReader extends AbstractReader {
     }
 
     @Override
-    public Pending<Object> get(String key, long record) {
-        Batch batch = batch();
-        int slot = batch.size();
-        batch.group.get(key, record);
-        return Pending.deferred(this, () -> batch.flush(concourse()).get(slot));
-    }
-
-    @Override
-    public Pending<Map<Long, Map<String, Set<Object>>>> navigate(
-            Set<String> keys, long record) {
-        Batch batch = batch();
-        int slot = batch.size();
-        batch.group.navigate(ImmutableList.copyOf(keys), record);
-        return Pending.deferred(this, () -> mapByRecord(batch, slot));
-    }
-
-    @Override
-    public Pending<Map<Long, Map<String, Set<Object>>>> navigate(
-            Set<String> keys, Criteria criteria) {
-        Batch batch = batch();
-        int slot = batch.size();
-        batch.group.navigate(ImmutableList.copyOf(keys), criteria);
-        return Pending.deferred(this, () -> mapByRecord(batch, slot));
-    }
-
-    @Override
-    public Pending<Map<Long, Map<String, Set<Object>>>> navigate(
-            Set<String> keys, Collection<Long> records) {
-        Batch batch = batch();
-        int slot = batch.size();
-        batch.group.navigate(ImmutableList.copyOf(keys), records);
-        return Pending.deferred(this, () -> mapByRecord(batch, slot));
-    }
-
-    @Override
-    public Pending<Set<Long>> find(Criteria criteria) {
-        Batch batch = batch();
-        int slot = batch.size();
-        batch.group.find(criteria);
-        return Pending.deferred(this, () -> ids(batch, slot));
-    }
-
-    @Override
-    public Pending<Long> count(String key, Criteria criteria) {
-        Batch batch = batch();
-        int slot = batch.size();
-        batch.group.count(key, criteria);
-        return Pending.deferred(this,
-                () -> ((Number) batch.flush(concourse()).get(slot))
-                        .longValue());
-    }
-
-    @Override
-    public Pending<Long> time() {
+    public Pending<Timestamp> time() {
         Batch batch = batch();
         int slot = batch.size();
         batch.group.time();
         return Pending.deferred(this,
-                () -> ((Timestamp) batch.flush(concourse()).get(slot))
-                        .getMicros());
+                () -> ((Timestamp) batch.flush(concourse()).get(slot)));
     }
 
     @Override

--- a/src/main/java/com/cinchapi/runway/db/BatchSaver.java
+++ b/src/main/java/com/cinchapi/runway/db/BatchSaver.java
@@ -99,6 +99,12 @@ public final class BatchSaver implements Saver {
     private final List<Consumer<CommandGroup>> deferredWriteOps;
 
     /**
+     * The server timestamp at or after the most recent {@link #commit()}, in
+     * microseconds.
+     */
+    private long commitTimestamp;
+
+    /**
      * Construct a new {@link BatchSaver} that submits against
      * {@code concourse}.
      *
@@ -226,8 +232,18 @@ public final class BatchSaver implements Saver {
         }
         int commitSlot = writes.commands().size();
         writes.commit();
+        // NOTE: time() must follow commit() so the checkpoint timestamp is
+        // not earlier than the revisions this transaction commits.
+        int timeSlot = writes.commands().size();
+        writes.time();
         List<Object> results = concourse.submit(writes);
+        commitTimestamp = ((Timestamp) results.get(timeSlot)).getMicros();
         return (Boolean) results.get(commitSlot);
+    }
+
+    @Override
+    public long commitTimestamp() {
+        return commitTimestamp;
     }
 
     @Override

--- a/src/main/java/com/cinchapi/runway/db/BatchSaver.java
+++ b/src/main/java/com/cinchapi/runway/db/BatchSaver.java
@@ -116,8 +116,8 @@ public final class BatchSaver implements Saver {
     }
 
     @Override
-    public void stage() {
-        stageRequested = true;
+    public void abort() {
+        concourse.abort();
     }
 
     @SuppressWarnings("unchecked")
@@ -137,6 +137,33 @@ public final class BatchSaver implements Saver {
         });
     }
 
+    @Override
+    public void clear(long record) {
+        deferredWriteOps.add(group -> group.clear(record));
+    }
+
+    @Override
+    public void clear(String key, long record) {
+        deferredWriteOps.add(group -> group.clear(key, record));
+    }
+
+    @Override
+    public boolean commit() {
+        flushReads();
+        CommandGroup writes = concourse.prepare();
+        if(stageRequested && !stageBundled) {
+            writes.stage();
+            stageBundled = true;
+        }
+        for (Consumer<CommandGroup> op : deferredWriteOps) {
+            op.accept(writes);
+        }
+        int commitSlot = writes.commands().size();
+        writes.commit();
+        List<Object> results = concourse.submit(writes);
+        return (Boolean) results.get(commitSlot);
+    }
+
     @SuppressWarnings("unchecked")
     @Override
     public void find(Criteria criteria, Consumer<Set<Long>> validator) {
@@ -150,49 +177,6 @@ public final class BatchSaver implements Saver {
             Set<Long> result = (Set<Long>) results.get(slot[0]);
             validator.accept(result);
         });
-    }
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public void select(String key, Criteria criteria,
-            Consumer<Map<Long, Set<Object>>> consumer) {
-        Preconditions.checkNotNull(consumer);
-        int[] slot = new int[1];
-        postWriteReadOps.add(group -> {
-            slot[0] = group.commands().size();
-            group.select(key, criteria);
-        });
-        pendingValidators.add(results -> {
-            Map<Long, Set<Object>> result = (Map<Long, Set<Object>>) results
-                    .get(slot[0]);
-            consumer.accept(result);
-        });
-        flushReads();
-    }
-
-    @Override
-    public long time() {
-        return concourse.time().getMicros();
-    }
-
-    @Override
-    public void set(String key, Object value, long record) {
-        deferredWriteOps.add(group -> group.set(key, value, record));
-    }
-
-    @Override
-    public void clear(String key, long record) {
-        deferredWriteOps.add(group -> group.clear(key, record));
-    }
-
-    @Override
-    public void clear(long record) {
-        deferredWriteOps.add(group -> group.clear(record));
-    }
-
-    @Override
-    public void verifyOrSet(String key, Object value, long record) {
-        deferredWriteOps.add(group -> group.verifyOrSet(key, value, record));
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
@@ -218,26 +202,55 @@ public final class BatchSaver implements Saver {
         }
     }
 
+    @SuppressWarnings("unchecked")
     @Override
-    public boolean commit() {
+    public void select(String key, Criteria criteria,
+            Consumer<Map<Long, Set<Object>>> consumer) {
+        Preconditions.checkNotNull(consumer);
+        int[] slot = new int[1];
+        postWriteReadOps.add(group -> {
+            slot[0] = group.commands().size();
+            group.select(key, criteria);
+        });
+        pendingValidators.add(results -> {
+            Map<Long, Set<Object>> result = (Map<Long, Set<Object>>) results
+                    .get(slot[0]);
+            consumer.accept(result);
+        });
         flushReads();
-        CommandGroup writes = concourse.prepare();
-        if(stageRequested && !stageBundled) {
-            writes.stage();
-            stageBundled = true;
-        }
-        for (Consumer<CommandGroup> op : deferredWriteOps) {
-            op.accept(writes);
-        }
-        int commitSlot = writes.commands().size();
-        writes.commit();
-        List<Object> results = concourse.submit(writes);
-        return (Boolean) results.get(commitSlot);
     }
 
     @Override
-    public void abort() {
-        concourse.abort();
+    public void set(String key, Object value, long record) {
+        deferredWriteOps.add(group -> group.set(key, value, record));
+    }
+
+    @Override
+    public void stage() {
+        stageRequested = true;
+    }
+
+    @Override
+    public void time(Consumer<Timestamp> consumer) {
+        if(stageRequested) {
+            int[] slot = new int[1];
+            postWriteReadOps.add(group -> {
+                slot[0] = group.commands().size();
+                group.time();
+            });
+            pendingValidators.add(results -> {
+                consumer.accept((Timestamp) results.get(slot[0]));
+            });
+            flushReads();
+        }
+        else {
+            consumer.accept(concourse.time());
+        }
+    }
+
+    @Override
+    public void verifyOrSet(String key, Object value, long record) {
+        deferredWriteOps.add(group -> group.verifyOrSet(key, value, record));
     }
 
     /**

--- a/src/main/java/com/cinchapi/runway/db/BatchSaver.java
+++ b/src/main/java/com/cinchapi/runway/db/BatchSaver.java
@@ -148,7 +148,7 @@ public final class BatchSaver implements Saver {
     }
 
     @Override
-    public boolean commit() {
+    public Timestamp commit() {
         flushReads();
         CommandGroup writes = concourse.prepare();
         if(stageRequested && !stageBundled) {
@@ -160,8 +160,15 @@ public final class BatchSaver implements Saver {
         }
         int commitSlot = writes.commands().size();
         writes.commit();
+        int timeSlot = writes.commands().size();
+        writes.time();
         List<Object> results = concourse.submit(writes);
-        return (Boolean) results.get(commitSlot);
+        if((Boolean) results.get(commitSlot)) {
+            return (Timestamp) results.get(timeSlot);
+        }
+        else {
+            return null;
+        }
     }
 
     @SuppressWarnings("unchecked")
@@ -228,24 +235,6 @@ public final class BatchSaver implements Saver {
     @Override
     public void stage() {
         stageRequested = true;
-    }
-
-    @Override
-    public void time(Consumer<Timestamp> consumer) {
-        if(stageRequested) {
-            int[] slot = new int[1];
-            postWriteReadOps.add(group -> {
-                slot[0] = group.commands().size();
-                group.time();
-            });
-            pendingValidators.add(results -> {
-                consumer.accept((Timestamp) results.get(slot[0]));
-            });
-            flushReads();
-        }
-        else {
-            consumer.accept(concourse.time());
-        }
     }
 
     @Override

--- a/src/main/java/com/cinchapi/runway/db/BatchSaver.java
+++ b/src/main/java/com/cinchapi/runway/db/BatchSaver.java
@@ -99,12 +99,6 @@ public final class BatchSaver implements Saver {
     private final List<Consumer<CommandGroup>> deferredWriteOps;
 
     /**
-     * The {@link Consumer} to deliver the post-commit server time to, or
-     * {@code null} when no {@link #time(Consumer) time} read was recorded.
-     */
-    private Consumer<Long> timeConsumer;
-
-    /**
      * Construct a new {@link BatchSaver} that submits against
      * {@code concourse}.
      *
@@ -177,11 +171,6 @@ public final class BatchSaver implements Saver {
     }
 
     @Override
-    public void time(Consumer<Long> consumer) {
-        this.timeConsumer = consumer;
-    }
-
-    @Override
     public void set(String key, Object value, long record) {
         deferredWriteOps.add(group -> group.set(key, value, record));
     }
@@ -237,20 +226,8 @@ public final class BatchSaver implements Saver {
         }
         int commitSlot = writes.commands().size();
         writes.commit();
-        int timeSlot = -1;
-        if(timeConsumer != null) {
-            // NOTE: time() follows commit() so the recorded server time is
-            // not earlier than the revisions this transaction commits.
-            timeSlot = writes.commands().size();
-            writes.time();
-        }
         List<Object> results = concourse.submit(writes);
-        boolean committed = (Boolean) results.get(commitSlot);
-        if(committed && timeConsumer != null) {
-            timeConsumer.accept(
-                    ((Timestamp) results.get(timeSlot)).getMicros());
-        }
-        return committed;
+        return (Boolean) results.get(commitSlot);
     }
 
     @Override

--- a/src/main/java/com/cinchapi/runway/db/BatchSaver.java
+++ b/src/main/java/com/cinchapi/runway/db/BatchSaver.java
@@ -99,10 +99,10 @@ public final class BatchSaver implements Saver {
     private final List<Consumer<CommandGroup>> deferredWriteOps;
 
     /**
-     * The server timestamp at or after the most recent {@link #commit()}, in
-     * microseconds.
+     * The {@link Consumer} to deliver the post-commit server time to, or
+     * {@code null} when no {@link #time(Consumer) time} read was recorded.
      */
-    private long commitTimestamp;
+    private Consumer<Long> timeConsumer;
 
     /**
      * Construct a new {@link BatchSaver} that submits against
@@ -177,6 +177,11 @@ public final class BatchSaver implements Saver {
     }
 
     @Override
+    public void time(Consumer<Long> consumer) {
+        this.timeConsumer = consumer;
+    }
+
+    @Override
     public void set(String key, Object value, long record) {
         deferredWriteOps.add(group -> group.set(key, value, record));
     }
@@ -232,18 +237,20 @@ public final class BatchSaver implements Saver {
         }
         int commitSlot = writes.commands().size();
         writes.commit();
-        // NOTE: time() must follow commit() so the checkpoint timestamp is
-        // not earlier than the revisions this transaction commits.
-        int timeSlot = writes.commands().size();
-        writes.time();
+        int timeSlot = -1;
+        if(timeConsumer != null) {
+            // NOTE: time() follows commit() so the recorded server time is
+            // not earlier than the revisions this transaction commits.
+            timeSlot = writes.commands().size();
+            writes.time();
+        }
         List<Object> results = concourse.submit(writes);
-        commitTimestamp = ((Timestamp) results.get(timeSlot)).getMicros();
-        return (Boolean) results.get(commitSlot);
-    }
-
-    @Override
-    public long commitTimestamp() {
-        return commitTimestamp;
+        boolean committed = (Boolean) results.get(commitSlot);
+        if(committed && timeConsumer != null) {
+            timeConsumer.accept(
+                    ((Timestamp) results.get(timeSlot)).getMicros());
+        }
+        return committed;
     }
 
     @Override

--- a/src/main/java/com/cinchapi/runway/db/BatchSaver.java
+++ b/src/main/java/com/cinchapi/runway/db/BatchSaver.java
@@ -171,6 +171,11 @@ public final class BatchSaver implements Saver {
     }
 
     @Override
+    public long time() {
+        return concourse.time().getMicros();
+    }
+
+    @Override
     public void set(String key, Object value, long record) {
         deferredWriteOps.add(group -> group.set(key, value, record));
     }

--- a/src/main/java/com/cinchapi/runway/db/IncrementalReader.java
+++ b/src/main/java/com/cinchapi/runway/db/IncrementalReader.java
@@ -23,6 +23,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 
 import com.cinchapi.concourse.Concourse;
 import com.cinchapi.concourse.ConnectionPool;
+import com.cinchapi.concourse.Timestamp;
 import com.cinchapi.concourse.lang.Criteria;
 import com.cinchapi.concourse.lang.paginate.Page;
 import com.cinchapi.concourse.lang.sort.Order;
@@ -37,18 +38,6 @@ import com.cinchapi.concourse.lang.sort.Order;
 public class IncrementalReader extends AbstractReader {
 
     /**
-     * Construct an {@link IncrementalReader} that borrows a {@link Concourse}
-     * connection from {@code pool} and returns it to {@code pool} on
-     * {@link #close()}.
-     *
-     * @param pool the {@link ConnectionPool} that owns the {@link Concourse}
-     *            connection; must not be {@code null}
-     */
-    public IncrementalReader(ConnectionPool pool) {
-        super(pool);
-    }
-
-    /**
      * Construct an {@link IncrementalReader} that issues against
      * {@code connection}. The caller retains ownership of the connection
      * lifecycle; {@link #close()} does <strong>not</strong> close it.
@@ -60,52 +49,49 @@ public class IncrementalReader extends AbstractReader {
         super(connection);
     }
 
-    @Override
-    public Pending<Map<Long, Map<String, Set<Object>>>> select(
-            Criteria criteria) {
-        return Pending.of(concourse().select(criteria));
+    /**
+     * Construct an {@link IncrementalReader} that borrows a {@link Concourse}
+     * connection from {@code pool} and returns it to {@code pool} on
+     * {@link #close()}.
+     *
+     * @param pool the {@link ConnectionPool} that owns the {@link Concourse}
+     *            connection; must not be {@code null}
+     */
+    public IncrementalReader(ConnectionPool pool) {
+        super(pool);
     }
 
     @Override
-    public Pending<Map<Long, Map<String, Set<Object>>>> select(Set<String> keys,
-            Criteria criteria) {
-        return Pending.of(concourse().select(keys, criteria));
+    public Pending<Long> count(String key, Criteria criteria) {
+        return Pending.of(concourse().calculate().count(key, criteria));
     }
 
     @Override
-    public Pending<Map<Long, Map<String, Set<Object>>>> select(
-            Criteria criteria, Order order) {
-        return Pending.of(concourse().select(criteria, order));
+    public Pending<Set<Long>> find(Criteria criteria) {
+        return Pending.of(concourse().find(criteria));
     }
 
     @Override
-    public Pending<Map<Long, Map<String, Set<Object>>>> select(Set<String> keys,
-            Criteria criteria, Order order) {
-        return Pending.of(concourse().select(keys, criteria, order));
+    public Pending<Object> get(String key, long record) {
+        return Pending.of(concourse().get(key, record));
     }
 
     @Override
-    public Pending<Map<Long, Map<String, Set<Object>>>> select(
-            Criteria criteria, Page page) {
-        return Pending.of(concourse().select(criteria, page));
+    public Pending<Map<Long, Map<String, Set<Object>>>> navigate(
+            Set<String> keys, Collection<Long> records) {
+        return Pending.of(concourse().navigate(keys, records));
     }
 
     @Override
-    public Pending<Map<Long, Map<String, Set<Object>>>> select(Set<String> keys,
-            Criteria criteria, Page page) {
-        return Pending.of(concourse().select(keys, criteria, page));
+    public Pending<Map<Long, Map<String, Set<Object>>>> navigate(
+            Set<String> keys, Criteria criteria) {
+        return Pending.of(concourse().navigate(keys, criteria));
     }
 
     @Override
-    public Pending<Map<Long, Map<String, Set<Object>>>> select(
-            Criteria criteria, Order order, Page page) {
-        return Pending.of(concourse().select(criteria, order, page));
-    }
-
-    @Override
-    public Pending<Map<Long, Map<String, Set<Object>>>> select(Set<String> keys,
-            Criteria criteria, Order order, Page page) {
-        return Pending.of(concourse().select(keys, criteria, order, page));
+    public Pending<Map<Long, Map<String, Set<Object>>>> navigate(
+            Set<String> keys, long record) {
+        return Pending.of(concourse().navigate(keys, record));
     }
 
     @Override
@@ -115,8 +101,56 @@ public class IncrementalReader extends AbstractReader {
     }
 
     @Override
+    public Pending<Map<Long, Map<String, Set<Object>>>> select(
+            Criteria criteria) {
+        return Pending.of(concourse().select(criteria));
+    }
+
+    @Override
+    public Pending<Map<Long, Map<String, Set<Object>>>> select(
+            Criteria criteria, Order order) {
+        return Pending.of(concourse().select(criteria, order));
+    }
+
+    @Override
+    public Pending<Map<Long, Map<String, Set<Object>>>> select(
+            Criteria criteria, Order order, Page page) {
+        return Pending.of(concourse().select(criteria, order, page));
+    }
+
+    @Override
+    public Pending<Map<Long, Map<String, Set<Object>>>> select(
+            Criteria criteria, Page page) {
+        return Pending.of(concourse().select(criteria, page));
+    }
+
+    @Override
     public Pending<Map<String, Set<Object>>> select(long record) {
         return Pending.of(concourse().select(record));
+    }
+
+    @Override
+    public Pending<Map<Long, Map<String, Set<Object>>>> select(Set<String> keys,
+            Criteria criteria) {
+        return Pending.of(concourse().select(keys, criteria));
+    }
+
+    @Override
+    public Pending<Map<Long, Map<String, Set<Object>>>> select(Set<String> keys,
+            Criteria criteria, Order order) {
+        return Pending.of(concourse().select(keys, criteria, order));
+    }
+
+    @Override
+    public Pending<Map<Long, Map<String, Set<Object>>>> select(Set<String> keys,
+            Criteria criteria, Order order, Page page) {
+        return Pending.of(concourse().select(keys, criteria, order, page));
+    }
+
+    @Override
+    public Pending<Map<Long, Map<String, Set<Object>>>> select(Set<String> keys,
+            Criteria criteria, Page page) {
+        return Pending.of(concourse().select(keys, criteria, page));
     }
 
     @Override
@@ -131,41 +165,8 @@ public class IncrementalReader extends AbstractReader {
     }
 
     @Override
-    public Pending<Object> get(String key, long record) {
-        return Pending.of(concourse().get(key, record));
-    }
-
-    @Override
-    public Pending<Map<Long, Map<String, Set<Object>>>> navigate(
-            Set<String> keys, long record) {
-        return Pending.of(concourse().navigate(keys, record));
-    }
-
-    @Override
-    public Pending<Map<Long, Map<String, Set<Object>>>> navigate(
-            Set<String> keys, Criteria criteria) {
-        return Pending.of(concourse().navigate(keys, criteria));
-    }
-
-    @Override
-    public Pending<Map<Long, Map<String, Set<Object>>>> navigate(
-            Set<String> keys, Collection<Long> records) {
-        return Pending.of(concourse().navigate(keys, records));
-    }
-
-    @Override
-    public Pending<Set<Long>> find(Criteria criteria) {
-        return Pending.of(concourse().find(criteria));
-    }
-
-    @Override
-    public Pending<Long> count(String key, Criteria criteria) {
-        return Pending.of(concourse().calculate().count(key, criteria));
-    }
-
-    @Override
-    public Pending<Long> time() {
-        return Pending.of(concourse().time().getMicros());
+    public Pending<Timestamp> time() {
+        return Pending.of(concourse().time());
     }
 
     @Override

--- a/src/main/java/com/cinchapi/runway/db/IncrementalReader.java
+++ b/src/main/java/com/cinchapi/runway/db/IncrementalReader.java
@@ -164,6 +164,11 @@ public class IncrementalReader extends AbstractReader {
     }
 
     @Override
+    public Pending<Long> time() {
+        return Pending.of(concourse().time().getMicros());
+    }
+
+    @Override
     protected void prepareDrain() {/* no-op */}
 
 }

--- a/src/main/java/com/cinchapi/runway/db/IncrementalSaver.java
+++ b/src/main/java/com/cinchapi/runway/db/IncrementalSaver.java
@@ -50,6 +50,12 @@ public final class IncrementalSaver implements Saver {
     private final Concourse concourse;
 
     /**
+     * The server timestamp at or after the most recent {@link #commit()}, in
+     * microseconds.
+     */
+    private long commitTimestamp;
+
+    /**
      * Construct a new {@link IncrementalSaver} backed by {@code concourse}.
      *
      * @param concourse the {@link Concourse} connection that every recording
@@ -66,7 +72,16 @@ public final class IncrementalSaver implements Saver {
 
     @Override
     public boolean commit() {
-        return concourse.commit();
+        boolean committed = concourse.commit();
+        if(committed) {
+            commitTimestamp = concourse.time().getMicros();
+        }
+        return committed;
+    }
+
+    @Override
+    public long commitTimestamp() {
+        return commitTimestamp;
     }
 
     @Override

--- a/src/main/java/com/cinchapi/runway/db/IncrementalSaver.java
+++ b/src/main/java/com/cinchapi/runway/db/IncrementalSaver.java
@@ -60,16 +60,6 @@ public final class IncrementalSaver implements Saver {
     }
 
     @Override
-    public void stage() {
-        concourse.stage();
-    }
-
-    @Override
-    public boolean commit() {
-        return concourse.commit();
-    }
-
-    @Override
     public void abort() {
         concourse.abort();
     }
@@ -81,24 +71,8 @@ public final class IncrementalSaver implements Saver {
     }
 
     @Override
-    public void find(Criteria criteria, Consumer<Set<Long>> validator) {
-        validator.accept(concourse.find(criteria));
-    }
-
-    @Override
-    public void select(String key, Criteria criteria,
-            Consumer<Map<Long, Set<Object>>> consumer) {
-        consumer.accept(concourse.select(key, criteria));
-    }
-
-    @Override
-    public long time() {
-        return concourse.time().getMicros();
-    }
-
-    @Override
-    public void set(String key, Object value, long record) {
-        concourse.set(key, value, record);
+    public void clear(long record) {
+        concourse.clear(record);
     }
 
     @Override
@@ -107,13 +81,13 @@ public final class IncrementalSaver implements Saver {
     }
 
     @Override
-    public void clear(long record) {
-        concourse.clear(record);
+    public boolean commit() {
+        return concourse.commit();
     }
 
     @Override
-    public void verifyOrSet(String key, Object value, long record) {
-        concourse.verifyOrSet(key, value, record);
+    public void find(Criteria criteria, Consumer<Set<Long>> validator) {
+        validator.accept(concourse.find(criteria));
     }
 
     @Override
@@ -134,6 +108,32 @@ public final class IncrementalSaver implements Saver {
         else {
             concourse.reconcile(key, record, values);
         }
+    }
+
+    @Override
+    public void select(String key, Criteria criteria,
+            Consumer<Map<Long, Set<Object>>> consumer) {
+        consumer.accept(concourse.select(key, criteria));
+    }
+
+    @Override
+    public void set(String key, Object value, long record) {
+        concourse.set(key, value, record);
+    }
+
+    @Override
+    public void stage() {
+        concourse.stage();
+    }
+
+    @Override
+    public void time(Consumer<Timestamp> consumer) {
+        consumer.accept(concourse.time());
+    }
+
+    @Override
+    public void verifyOrSet(String key, Object value, long record) {
+        concourse.verifyOrSet(key, value, record);
     }
 
 }

--- a/src/main/java/com/cinchapi/runway/db/IncrementalSaver.java
+++ b/src/main/java/com/cinchapi/runway/db/IncrementalSaver.java
@@ -92,6 +92,11 @@ public final class IncrementalSaver implements Saver {
     }
 
     @Override
+    public long time() {
+        return concourse.time().getMicros();
+    }
+
+    @Override
     public void set(String key, Object value, long record) {
         concourse.set(key, value, record);
     }

--- a/src/main/java/com/cinchapi/runway/db/IncrementalSaver.java
+++ b/src/main/java/com/cinchapi/runway/db/IncrementalSaver.java
@@ -81,8 +81,13 @@ public final class IncrementalSaver implements Saver {
     }
 
     @Override
-    public boolean commit() {
-        return concourse.commit();
+    public Timestamp commit() {
+        if(concourse.commit()) {
+            return concourse.time();
+        }
+        else {
+            return null;
+        }
     }
 
     @Override
@@ -124,11 +129,6 @@ public final class IncrementalSaver implements Saver {
     @Override
     public void stage() {
         concourse.stage();
-    }
-
-    @Override
-    public void time(Consumer<Timestamp> consumer) {
-        consumer.accept(concourse.time());
     }
 
     @Override

--- a/src/main/java/com/cinchapi/runway/db/IncrementalSaver.java
+++ b/src/main/java/com/cinchapi/runway/db/IncrementalSaver.java
@@ -50,10 +50,10 @@ public final class IncrementalSaver implements Saver {
     private final Concourse concourse;
 
     /**
-     * The server timestamp at or after the most recent {@link #commit()}, in
-     * microseconds.
+     * The {@link Consumer} to deliver the post-commit server time to, or
+     * {@code null} when no {@link #time(Consumer) time} read was recorded.
      */
-    private long commitTimestamp;
+    private Consumer<Long> timeConsumer;
 
     /**
      * Construct a new {@link IncrementalSaver} backed by {@code concourse}.
@@ -73,15 +73,10 @@ public final class IncrementalSaver implements Saver {
     @Override
     public boolean commit() {
         boolean committed = concourse.commit();
-        if(committed) {
-            commitTimestamp = concourse.time().getMicros();
+        if(committed && timeConsumer != null) {
+            timeConsumer.accept(concourse.time().getMicros());
         }
         return committed;
-    }
-
-    @Override
-    public long commitTimestamp() {
-        return commitTimestamp;
     }
 
     @Override
@@ -104,6 +99,11 @@ public final class IncrementalSaver implements Saver {
     public void select(String key, Criteria criteria,
             Consumer<Map<Long, Set<Object>>> consumer) {
         consumer.accept(concourse.select(key, criteria));
+    }
+
+    @Override
+    public void time(Consumer<Long> consumer) {
+        this.timeConsumer = consumer;
     }
 
     @Override

--- a/src/main/java/com/cinchapi/runway/db/IncrementalSaver.java
+++ b/src/main/java/com/cinchapi/runway/db/IncrementalSaver.java
@@ -50,12 +50,6 @@ public final class IncrementalSaver implements Saver {
     private final Concourse concourse;
 
     /**
-     * The {@link Consumer} to deliver the post-commit server time to, or
-     * {@code null} when no {@link #time(Consumer) time} read was recorded.
-     */
-    private Consumer<Long> timeConsumer;
-
-    /**
      * Construct a new {@link IncrementalSaver} backed by {@code concourse}.
      *
      * @param concourse the {@link Concourse} connection that every recording
@@ -72,11 +66,7 @@ public final class IncrementalSaver implements Saver {
 
     @Override
     public boolean commit() {
-        boolean committed = concourse.commit();
-        if(committed && timeConsumer != null) {
-            timeConsumer.accept(concourse.time().getMicros());
-        }
-        return committed;
+        return concourse.commit();
     }
 
     @Override
@@ -99,11 +89,6 @@ public final class IncrementalSaver implements Saver {
     public void select(String key, Criteria criteria,
             Consumer<Map<Long, Set<Object>>> consumer) {
         consumer.accept(concourse.select(key, criteria));
-    }
-
-    @Override
-    public void time(Consumer<Long> consumer) {
-        this.timeConsumer = consumer;
     }
 
     @Override

--- a/src/main/java/com/cinchapi/runway/db/Reader.java
+++ b/src/main/java/com/cinchapi/runway/db/Reader.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Set;
 
 import com.cinchapi.concourse.Concourse;
+import com.cinchapi.concourse.Timestamp;
 import com.cinchapi.concourse.lang.Criteria;
 import com.cinchapi.concourse.lang.paginate.Page;
 import com.cinchapi.concourse.lang.sort.Order;
@@ -243,7 +244,7 @@ public interface Reader extends AutoCloseable {
      *
      * @return a {@link Pending} of the server time, in microseconds
      */
-    Pending<Long> time();
+    Pending<Timestamp> time();
 
     /**
      * Return the underlying {@link Concourse} connection that this

--- a/src/main/java/com/cinchapi/runway/db/Reader.java
+++ b/src/main/java/com/cinchapi/runway/db/Reader.java
@@ -239,6 +239,13 @@ public interface Reader extends AutoCloseable {
     Pending<Long> count(String key, Criteria criteria);
 
     /**
+     * Record a read of the database server's current time.
+     *
+     * @return a {@link Pending} of the server time, in microseconds
+     */
+    Pending<Long> time();
+
+    /**
      * Return the underlying {@link Concourse} connection that this
      * {@link Reader} wraps, acquiring one from the
      * {@link com.cinchapi.concourse.ConnectionPool ConnectionPool} if the

--- a/src/main/java/com/cinchapi/runway/db/Saver.java
+++ b/src/main/java/com/cinchapi/runway/db/Saver.java
@@ -158,19 +158,6 @@ public interface Saver {
             Consumer<Map<Long, Set<Object>>> consumer);
 
     /**
-     * Record a read of the database server's time as of this save's commit
-     * and arrange to deliver it to {@code consumer}.
-     * <p>
-     * The {@code consumer} runs after a successful {@link #commit()} and does
-     * not run if the commit fails.
-     * </p>
-     *
-     * @param consumer a {@link Consumer} that receives the post-commit server
-     *            time, in microseconds
-     */
-    void time(Consumer<Long> consumer);
-
-    /**
      * Record a {@link Concourse#set(String, Object, long) set} of {@code value}
      * for {@code key} in {@code record}.
      *

--- a/src/main/java/com/cinchapi/runway/db/Saver.java
+++ b/src/main/java/com/cinchapi/runway/db/Saver.java
@@ -21,6 +21,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 
+import javax.annotation.Nullable;
+
 import com.cinchapi.concourse.Concourse;
 import com.cinchapi.concourse.Timestamp;
 import com.cinchapi.concourse.lang.Criteria;
@@ -97,17 +99,8 @@ public interface Saver {
     void clear(String key, long record);
 
     /**
-     * Commit the staged transaction.
-     * <p>
-     * For synchronous implementations this delegates straight to the underlying
-     * connection's commit. Bulk implementations submit accumulated recordings
-     * with as few round trips as the save permits. When no validation reads
-     * were recorded, a single submission carries {@link #stage()}, every write,
-     * and the terminal commit. When validation reads were recorded, they are
-     * submitted first &mdash; alongside the writes &mdash; so every queued
-     * validator can run against the result; the commit then follows in a second
-     * submission once validation passes.
-     * </p>
+     * Commit the staged transaction and return the post-commit server
+     * {@link Timestamp}.
      * <p>
      * If a queued validator throws, the commit is <strong>not</strong>
      * submitted. The writes share the validation submission and have therefore
@@ -116,11 +109,12 @@ public interface Saver {
      * roll them back.
      * </p>
      *
-     * @return {@code true} if the staged transaction committed; {@code false}
-     *         if the server rejected the commit (e.g. a spurious commit failure
-     *         that the caller may retry)
+     * @return the server {@link Timestamp} after a successful commit, or
+     *         {@code null} if the server rejected the commit (e.g. a spurious
+     *         commit failure that the caller may retry)
      */
-    boolean commit();
+    @Nullable
+    Timestamp commit();
 
     /**
      * Record a {@link Concourse#find(Criteria) find} for the {@code criteria}
@@ -221,15 +215,6 @@ public interface Saver {
      * </p>
      */
     void stage();
-
-    /**
-     * Record a read of the database server's current time and arrange to apply
-     * {@code consumer} to the resulting {@link Timestamp}.
-     *
-     * @param consumer a {@link Consumer} that receives the server
-     *            {@link Timestamp}
-     */
-    void time(Consumer<Timestamp> consumer);
 
     /**
      * Record a {@link Concourse#verifyOrSet(String, Object, long) verifyOrSet}

--- a/src/main/java/com/cinchapi/runway/db/Saver.java
+++ b/src/main/java/com/cinchapi/runway/db/Saver.java
@@ -54,15 +54,47 @@ import com.cinchapi.concourse.lang.Criteria;
 public interface Saver {
 
     /**
-     * Begin a staged transaction for the save this {@link Saver} represents.
+     * Abort the staged transaction.
      * <p>
-     * Must be called exactly once before any recording method. For synchronous
-     * implementations the stage takes effect on the server immediately; for
-     * bulk implementations the stage is recorded for execution as the first
-     * command of the read submission inside {@link #commit()}.
+     * Safe to call even when nothing has been submitted yet (for bulk
+     * implementations) &mdash; in that case the call is a no-op because no
+     * server-side state exists to roll back.
      * </p>
      */
-    void stage();
+    void abort();
+
+    /**
+     * Record an {@link Concourse#audit(long) audit} for {@code record} and
+     * arrange to apply {@code validator} to the result.
+     * <p>
+     * The {@code validator} may throw to signal a validation failure (typically
+     * {@link com.cinchapi.runway.StaleDataException}); the exception propagates
+     * from the recording call for synchronous implementations and from
+     * {@link #commit()} for bulk implementations.
+     * </p>
+     *
+     * @param record the record id whose change history is being inspected
+     * @param validator a {@link Consumer} that receives the audit result and
+     *            may throw to reject the save
+     */
+    void audit(long record, Consumer<Map<Timestamp, List<String>>> validator);
+
+    /**
+     * Record a {@link Concourse#clear(long) clear} of every value stored in
+     * {@code record}, leaving the record empty.
+     *
+     * @param record the record id to clear
+     */
+    void clear(long record);
+
+    /**
+     * Record a {@link Concourse#clear(String, long) clear} of all values for
+     * {@code key} in {@code record}.
+     *
+     * @param key the field name to clear
+     * @param record the record id to clear from
+     */
+    void clear(String key, long record);
 
     /**
      * Commit the staged transaction.
@@ -91,32 +123,6 @@ public interface Saver {
     boolean commit();
 
     /**
-     * Abort the staged transaction.
-     * <p>
-     * Safe to call even when nothing has been submitted yet (for bulk
-     * implementations) &mdash; in that case the call is a no-op because no
-     * server-side state exists to roll back.
-     * </p>
-     */
-    void abort();
-
-    /**
-     * Record an {@link Concourse#audit(long) audit} for {@code record} and
-     * arrange to apply {@code validator} to the result.
-     * <p>
-     * The {@code validator} may throw to signal a validation failure (typically
-     * {@link com.cinchapi.runway.StaleDataException}); the exception propagates
-     * from the recording call for synchronous implementations and from
-     * {@link #commit()} for bulk implementations.
-     * </p>
-     *
-     * @param record the record id whose change history is being inspected
-     * @param validator a {@link Consumer} that receives the audit result and
-     *            may throw to reject the save
-     */
-    void audit(long record, Consumer<Map<Timestamp, List<String>>> validator);
-
-    /**
      * Record a {@link Concourse#find(Criteria) find} for the {@code criteria}
      * and arrange to apply {@code validator} to the matching record ids.
      * <p>
@@ -132,74 +138,6 @@ public interface Saver {
      *            may throw to reject the save
      */
     void find(Criteria criteria, Consumer<Set<Long>> validator);
-
-    /**
-     * Record a {@link Concourse#select(String, Criteria) select} of values for
-     * {@code key} on every record matching {@code criteria} and arrange to
-     * apply {@code consumer} to the resulting record-keyed map.
-     * <p>
-     * Unlike {@link #audit audit} and {@link #find find}, this read drives
-     * control flow rather than a throw/no-throw validation &mdash; the
-     * {@code consumer} typically iterates the result and triggers further save
-     * work (e.g. cascade-delete loads). Implementations therefore guarantee
-     * that {@code consumer} runs before the recording call returns. For bulk
-     * implementations this means an early submission of any reads accumulated
-     * so far so the result is available; subsequent recordings start a fresh
-     * batch.
-     * </p>
-     *
-     * @param key the field name whose values should be returned
-     * @param criteria the {@link Criteria} that identifies the matching records
-     * @param consumer a {@link Consumer} that receives the result and may
-     *            mutate caller state, trigger further recordings on this
-     *            {@link Saver}, or throw to reject the save
-     */
-    void select(String key, Criteria criteria,
-            Consumer<Map<Long, Set<Object>>> consumer);
-
-    /**
-     * Return the database server's current time, in microseconds.
-     *
-     * @return the server time, in microseconds
-     */
-    long time();
-
-    /**
-     * Record a {@link Concourse#set(String, Object, long) set} of {@code value}
-     * for {@code key} in {@code record}.
-     *
-     * @param key the field name to set
-     * @param value the value to associate with {@code key}
-     * @param record the record id to set into
-     */
-    void set(String key, Object value, long record);
-
-    /**
-     * Record a {@link Concourse#clear(String, long) clear} of all values for
-     * {@code key} in {@code record}.
-     *
-     * @param key the field name to clear
-     * @param record the record id to clear from
-     */
-    void clear(String key, long record);
-
-    /**
-     * Record a {@link Concourse#clear(long) clear} of every value stored in
-     * {@code record}, leaving the record empty.
-     *
-     * @param record the record id to clear
-     */
-    void clear(long record);
-
-    /**
-     * Record a {@link Concourse#verifyOrSet(String, Object, long) verifyOrSet}
-     * of {@code value} for {@code key} in {@code record}.
-     *
-     * @param key the field name to verifyOrSet
-     * @param value the value to associate with {@code key}
-     * @param record the record id whose mapping is being verified or set
-     */
-    void verifyOrSet(String key, Object value, long record);
 
     /**
      * Record a {@link Concourse#reconcile(String, long, Collection) reconcile}
@@ -238,5 +176,69 @@ public interface Saver {
      *            {@link #clear(String, long)}
      */
     void reconcile(String key, long record, Object[] values);
+
+    /**
+     * Record a {@link Concourse#select(String, Criteria) select} of values for
+     * {@code key} on every record matching {@code criteria} and arrange to
+     * apply {@code consumer} to the resulting record-keyed map.
+     * <p>
+     * Unlike {@link #audit audit} and {@link #find find}, this read drives
+     * control flow rather than a throw/no-throw validation &mdash; the
+     * {@code consumer} typically iterates the result and triggers further save
+     * work (e.g. cascade-delete loads). Implementations therefore guarantee
+     * that {@code consumer} runs before the recording call returns. For bulk
+     * implementations this means an early submission of any reads accumulated
+     * so far so the result is available; subsequent recordings start a fresh
+     * batch.
+     * </p>
+     *
+     * @param key the field name whose values should be returned
+     * @param criteria the {@link Criteria} that identifies the matching records
+     * @param consumer a {@link Consumer} that receives the result and may
+     *            mutate caller state, trigger further recordings on this
+     *            {@link Saver}, or throw to reject the save
+     */
+    void select(String key, Criteria criteria,
+            Consumer<Map<Long, Set<Object>>> consumer);
+
+    /**
+     * Record a {@link Concourse#set(String, Object, long) set} of {@code value}
+     * for {@code key} in {@code record}.
+     *
+     * @param key the field name to set
+     * @param value the value to associate with {@code key}
+     * @param record the record id to set into
+     */
+    void set(String key, Object value, long record);
+
+    /**
+     * Begin a staged transaction for the save this {@link Saver} represents.
+     * <p>
+     * Must be called exactly once before any recording method. For synchronous
+     * implementations the stage takes effect on the server immediately; for
+     * bulk implementations the stage is recorded for execution as the first
+     * command of the read submission inside {@link #commit()}.
+     * </p>
+     */
+    void stage();
+
+    /**
+     * Record a read of the database server's current time and arrange to apply
+     * {@code consumer} to the resulting {@link Timestamp}.
+     *
+     * @param consumer a {@link Consumer} that receives the server
+     *            {@link Timestamp}
+     */
+    void time(Consumer<Timestamp> consumer);
+
+    /**
+     * Record a {@link Concourse#verifyOrSet(String, Object, long) verifyOrSet}
+     * of {@code value} for {@code key} in {@code record}.
+     *
+     * @param key the field name to verifyOrSet
+     * @param value the value to associate with {@code key}
+     * @param record the record id whose mapping is being verified or set
+     */
+    void verifyOrSet(String key, Object value, long record);
 
 }

--- a/src/main/java/com/cinchapi/runway/db/Saver.java
+++ b/src/main/java/com/cinchapi/runway/db/Saver.java
@@ -91,20 +91,6 @@ public interface Saver {
     boolean commit();
 
     /**
-     * Return a server timestamp, in microseconds, at or after the commit of the
-     * save this {@link Saver} represents.
-     * <p>
-     * Only meaningful after {@link #commit()} has returned {@code true}. The
-     * value is suitable as a stale-write checkpoint: it is not earlier than any
-     * revision this save wrote, so those revisions are not themselves treated
-     * as stale, and any later external revision is.
-     * </p>
-     *
-     * @return the post-commit server timestamp, in microseconds
-     */
-    long commitTimestamp();
-
-    /**
      * Abort the staged transaction.
      * <p>
      * Safe to call even when nothing has been submitted yet (for bulk
@@ -170,6 +156,19 @@ public interface Saver {
      */
     void select(String key, Criteria criteria,
             Consumer<Map<Long, Set<Object>>> consumer);
+
+    /**
+     * Record a read of the database server's time as of this save's commit
+     * and arrange to deliver it to {@code consumer}.
+     * <p>
+     * The {@code consumer} runs after a successful {@link #commit()} and does
+     * not run if the commit fails.
+     * </p>
+     *
+     * @param consumer a {@link Consumer} that receives the post-commit server
+     *            time, in microseconds
+     */
+    void time(Consumer<Long> consumer);
 
     /**
      * Record a {@link Concourse#set(String, Object, long) set} of {@code value}

--- a/src/main/java/com/cinchapi/runway/db/Saver.java
+++ b/src/main/java/com/cinchapi/runway/db/Saver.java
@@ -158,6 +158,13 @@ public interface Saver {
             Consumer<Map<Long, Set<Object>>> consumer);
 
     /**
+     * Return the database server's current time, in microseconds.
+     *
+     * @return the server time, in microseconds
+     */
+    long time();
+
+    /**
      * Record a {@link Concourse#set(String, Object, long) set} of {@code value}
      * for {@code key} in {@code record}.
      *

--- a/src/main/java/com/cinchapi/runway/db/Saver.java
+++ b/src/main/java/com/cinchapi/runway/db/Saver.java
@@ -91,6 +91,20 @@ public interface Saver {
     boolean commit();
 
     /**
+     * Return a server timestamp, in microseconds, at or after the commit of the
+     * save this {@link Saver} represents.
+     * <p>
+     * Only meaningful after {@link #commit()} has returned {@code true}. The
+     * value is suitable as a stale-write checkpoint: it is not earlier than any
+     * revision this save wrote, so those revisions are not themselves treated
+     * as stale, and any later external revision is.
+     * </p>
+     *
+     * @return the post-commit server timestamp, in microseconds
+     */
+    long commitTimestamp();
+
+    /**
      * Abort the staged transaction.
      * <p>
      * Safe to call even when nothing has been submitted yet (for bulk

--- a/src/test/java/com/cinchapi/runway/GH95.java
+++ b/src/test/java/com/cinchapi/runway/GH95.java
@@ -94,8 +94,8 @@ public class GH95 extends RunwayBaseClientServerTest {
         targets.put(p3.id(), client.select(p3.id()));
 
         Stone loaded = Record.load(Stone.class, stone.id(),
-                new ConcurrentHashMap<>(), runway.connections, runway, null,
-                targets);
+                new ConcurrentHashMap<>(), runway.connections, runway,
+                client.time().getMicros(), null, targets);
 
         Assert.assertNotNull(loaded);
         Assert.assertEquals(3, loaded.pebbles.size());
@@ -151,8 +151,8 @@ public class GH95 extends RunwayBaseClientServerTest {
         targets.put(p1.id(), overridden);
 
         Stone loaded = Record.load(Stone.class, stone.id(),
-                new ConcurrentHashMap<>(), runway.connections, runway, null,
-                targets);
+                new ConcurrentHashMap<>(), runway.connections, runway,
+                client.time().getMicros(), null, targets);
 
         Assert.assertNotNull(loaded);
         Assert.assertEquals(1, loaded.pebbles.size());

--- a/src/test/java/com/cinchapi/runway/GH95.java
+++ b/src/test/java/com/cinchapi/runway/GH95.java
@@ -94,8 +94,8 @@ public class GH95 extends RunwayBaseClientServerTest {
         targets.put(p3.id(), client.select(p3.id()));
 
         Stone loaded = Record.load(Stone.class, stone.id(),
-                new ConcurrentHashMap<>(), runway.connections, runway,
-                client.time().getMicros(), null, targets);
+                new ConcurrentHashMap<>(), runway.connections, runway, null,
+                targets);
 
         Assert.assertNotNull(loaded);
         Assert.assertEquals(3, loaded.pebbles.size());
@@ -151,8 +151,8 @@ public class GH95 extends RunwayBaseClientServerTest {
         targets.put(p1.id(), overridden);
 
         Stone loaded = Record.load(Stone.class, stone.id(),
-                new ConcurrentHashMap<>(), runway.connections, runway,
-                client.time().getMicros(), null, targets);
+                new ConcurrentHashMap<>(), runway.connections, runway, null,
+                targets);
 
         Assert.assertNotNull(loaded);
         Assert.assertEquals(1, loaded.pebbles.size());

--- a/src/test/java/com/cinchapi/runway/db/BatchSaverTest.java
+++ b/src/test/java/com/cinchapi/runway/db/BatchSaverTest.java
@@ -69,7 +69,7 @@ public class BatchSaverTest extends SaverTest {
         Assert.assertFalse("validator should defer until commit",
                 validatorRan.get());
 
-        Assert.assertTrue(saver.commit());
+        Assert.assertNotNull(saver.commit());
         Assert.assertTrue("validator should have run inside commit",
                 validatorRan.get());
     }
@@ -161,7 +161,7 @@ public class BatchSaverTest extends SaverTest {
                 result -> saver.find(Criteria.where().key("flag")
                         .operator(Operator.EQUALS).value(true),
                         nestedResult::set));
-        Assert.assertTrue(saver.commit());
+        Assert.assertNotNull(saver.commit());
 
         Assert.assertNotNull(nestedResult.get());
         Assert.assertTrue(nestedResult.get().contains(alpha));
@@ -215,7 +215,7 @@ public class BatchSaverTest extends SaverTest {
                                 Criteria.where().key("category")
                                         .operator(Operator.EQUALS).value("X"),
                                 findResult::set)));
-        Assert.assertTrue(saver.commit());
+        Assert.assertNotNull(saver.commit());
 
         Assert.assertNotNull(findResult.get());
         Assert.assertTrue(findResult.get().contains(match));

--- a/src/test/java/com/cinchapi/runway/db/SaverTest.java
+++ b/src/test/java/com/cinchapi/runway/db/SaverTest.java
@@ -78,7 +78,7 @@ public abstract class SaverTest extends RunwayBaseClientServerTest {
 
         saver.stage();
         saver.set("foo", "bar", id);
-        Assert.assertTrue(saver.commit());
+        Assert.assertNotNull(saver.commit());
 
         Assert.assertEquals(ImmutableSet.of("bar"), client.select("foo", id));
     }
@@ -113,7 +113,7 @@ public abstract class SaverTest extends RunwayBaseClientServerTest {
 
         saver.stage();
         saver.set("foo", "bar", id);
-        Assert.assertTrue(saver.commit());
+        Assert.assertNotNull(saver.commit());
 
         Assert.assertEquals(ImmutableSet.of("bar"), client.select("foo", id));
     }
@@ -146,7 +146,7 @@ public abstract class SaverTest extends RunwayBaseClientServerTest {
         Saver saver = newSaver();
         saver.stage();
         saver.reconcile("tags", id, ImmutableSet.of());
-        Assert.assertTrue(saver.commit());
+        Assert.assertNotNull(saver.commit());
 
         Assert.assertTrue(client.select("tags", id).isEmpty());
     }
@@ -178,7 +178,7 @@ public abstract class SaverTest extends RunwayBaseClientServerTest {
         Saver saver = newSaver();
         saver.stage();
         saver.reconcile("tags", id, new Object[0]);
-        Assert.assertTrue(saver.commit());
+        Assert.assertNotNull(saver.commit());
 
         Assert.assertTrue(client.select("tags", id).isEmpty());
     }
@@ -236,7 +236,7 @@ public abstract class SaverTest extends RunwayBaseClientServerTest {
         saver.stage();
         AtomicReference<Map<Timestamp, List<String>>> captured = new AtomicReference<>();
         saver.audit(id, captured::set);
-        Assert.assertTrue(saver.commit());
+        Assert.assertNotNull(saver.commit());
 
         Assert.assertNotNull(captured.get());
         Assert.assertFalse(captured.get().isEmpty());
@@ -265,7 +265,7 @@ public abstract class SaverTest extends RunwayBaseClientServerTest {
         Saver saver = newSaver();
         saver.stage();
         saver.clear("drop", id);
-        Assert.assertTrue(saver.commit());
+        Assert.assertNotNull(saver.commit());
 
         Assert.assertTrue(client.select("drop", id).isEmpty());
     }
@@ -293,7 +293,7 @@ public abstract class SaverTest extends RunwayBaseClientServerTest {
         Saver saver = newSaver();
         saver.stage();
         saver.clear(id);
-        Assert.assertTrue(saver.commit());
+        Assert.assertNotNull(saver.commit());
 
         Assert.assertTrue(client.select(id).isEmpty());
     }
@@ -317,7 +317,7 @@ public abstract class SaverTest extends RunwayBaseClientServerTest {
     public void testEmptyCommitSucceeds() {
         Saver saver = newSaver();
         saver.stage();
-        Assert.assertTrue(saver.commit());
+        Assert.assertNotNull(saver.commit());
     }
 
     /**
@@ -350,7 +350,7 @@ public abstract class SaverTest extends RunwayBaseClientServerTest {
         AtomicReference<Set<Long>> captured = new AtomicReference<>();
         saver.find(Criteria.where().key("flag").operator(Operator.EQUALS)
                 .value(true), captured::set);
-        Assert.assertTrue(saver.commit());
+        Assert.assertNotNull(saver.commit());
 
         Assert.assertEquals(ImmutableSet.of(match1, match2), captured.get());
     }
@@ -380,7 +380,7 @@ public abstract class SaverTest extends RunwayBaseClientServerTest {
         Saver saver = newSaver();
         saver.stage();
         saver.reconcile("tags", id, new Object[] { "b", "c" });
-        Assert.assertTrue(saver.commit());
+        Assert.assertNotNull(saver.commit());
 
         Assert.assertEquals(ImmutableSet.of("b", "c"),
                 client.select("tags", id));
@@ -410,7 +410,7 @@ public abstract class SaverTest extends RunwayBaseClientServerTest {
         Saver saver = newSaver();
         saver.stage();
         saver.set("foo", "bar", id);
-        Assert.assertTrue(saver.commit());
+        Assert.assertNotNull(saver.commit());
 
         Set<Object> values = client.select("foo", id);
         Assert.assertEquals(ImmutableSet.of("bar"), values);
@@ -486,7 +486,7 @@ public abstract class SaverTest extends RunwayBaseClientServerTest {
         Saver saver = newSaver();
         saver.stage();
         saver.verifyOrSet("k", "new", id);
-        Assert.assertTrue(saver.commit());
+        Assert.assertNotNull(saver.commit());
 
         Assert.assertEquals(ImmutableSet.of("new"), client.select("k", id));
     }


### PR DESCRIPTION
## Summary

Stacks on #119. Makes the stale-write checkpoint a server timestamp.

**Load side:** `time()` is a recorded call on `Reader` -- a peer of
`select` / `find` / `count` -- so a load rides one `time()` on its
read batch. The resulting server time threads explicitly through
record hydration.

**Save side:** the `Saver` abstraction stays pure save. `Runway.save`
-- the orchestrator -- reads the post-commit checkpoint with a plain
`Concourse.time()` once `commit()` returns.

No thread-local state, no `time()` on `Saver`, no bespoke
`commitTimestamp()`.

## Caveat

The load-side `time()` rides a `CommandGroup` (`BatchReader`), which
depends on Concourse cinchapi/concourse#752 -- the `TIME` verb is not
yet serializable in a `CommandGroup`. Batched reads will fail until
that lands. The save-side `Concourse.time()` and the non-batched
`IncrementalReader` path work today.

## Test plan

- [ ] Re-run the suite once cinchapi/concourse#752 is fixed
- [ ] `PreventStaleWriteTest` passes under shared-server reuse
- [ ] Stale-write detection holds across client and server clock skew