### PR TITLE
Save-path round-trip tests and 2.0.0 changelog clarification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Every `load`, `find`, and `findAny` operation now resolves linked `Record` data 
 
 * Self-referential `Record` graphs of arbitrary depth pre-fetch in a single round trip via the `*` transitive modifier; previously, self-referential `Collection<Record>` fields (e.g., `Exchange.children: Set<Exchange>`) and self-referential single-`Record` fields (e.g., `Exchange.parent: Exchange`) bounded pre-fetching at one level.
 * `Collection<Record>` fields reached through single-`Record` edges (e.g., `Document.metadata.tags`) and non-cyclic `Collection<Record>` fields nested under self-referential ones are now fully pre-fetched.
-* Untyped loads through `loadAny` / `findAny` now also benefit from `navigate()` pre-fetch &mdash; the load pipeline groups discovered records by their section key and dispatches a class-aware `navigate()` per group.
+* Untyped loads through `loadAny` / `findAny` now also benefit from `navigate()` pre-fetch &mdash; the load pipeline groups discovered records by their section key and dispatches a class-aware `navigate()` per group. An untyped load that touches `K` classes therefore costs one batched round trip per group, so the table's `1` applies to typed loads and to untyped loads whose results all belong to a single class.
 * The single-record `load(Class, id)` codepath is unified with the bulk pre-fetch path, so every load surface shares one mechanism.
 * Select-side path computation is unchanged.
 
@@ -27,7 +27,8 @@ On `2.0.0`, running against Concourse `1.0.x`, the new `*` transitive modifier r
 | --- | --- | --- |
 | `1.14.x` / `0.12.x` &mdash; `NONE`, no prefetch (the default) | `1 + N` | `1 + N` |
 | `1.14.x` / `0.12.x` &mdash; `BULK_SELECT`, batched per level | `1 + L` | `1 + D` |
-| `2.0.0` / `1.0.x` &mdash; unified transitive `navigate()` | `1` | `1` |
+| `2.0.0` / `1.0.x` &mdash; Command API and `*` modifier | `1` | `1` |
+| `2.0.0` / `0.12.x` &mdash; legacy fallback (no Command API or `*`) | `2` | `2 + D` |
 
 Each cell is the largest number of server round trips needed to fully resolve a single `load` or `find`. The formulas use three quantities:
 
@@ -37,9 +38,19 @@ Each cell is the largest number of server round trips needed to fully resolve a 
 
 No pre-fetch mechanism in the `1.14.x` line could resolve a self-referential tree in a number of round trips that did not grow with `D`. The `2.0.0` mechanism is the first that can.
 
-Two conditions sit behind the `2.0.0` column. The first is the server version. Every load makes two requests to Concourse: a `select` for the record itself, and a `navigate` that pre-fetches the records it links to. Concourse `1.0.x` provides the Command API described above, which lets Runway send both requests in one round trip; that is why the table shows `1` rather than `2`. When Runway 2.0.0 runs against an older server, it cannot combine the two requests, and every load costs one round trip more than the table shows.
+A `2.0.0` load has two independent optimization opportunities, both introduced in Concourse `1.0.0`:
 
-The second condition is the shape of the graph. The `*` modifier can repeat only one field name. `children*` follows a chain of `children` links, but it cannot follow a cycle that alternates between two different field names &mdash; for example, a type `A` that links to `B` through a field named `bs` while `B` links back through a field named `as`. A single `navigate()` therefore cannot reach an alternating-field cycle, nor a link whose target has been deleted. Whatever it misses is gathered afterward by a bulk-`select()` cleanup pass, and that pass costs one further round trip for every level of graph it still has to walk. A plain self-referential tree leaves nothing for it to do, so the tree resolves in exactly the round trips the table shows. A graph with alternating-field cycles costs one round trip for each level of the part `*` could not express.
+1. **The Command API** (`prepare()`/`submit()`) lets Runway pack the per-load `select` for the record itself and the `navigate` for the records it links to into a single round trip rather than two.
+
+2. **The `*` transitive modifier** to `navigate()` lets a single `navigate()` call follow a self-referential link to any depth. Runway emits `*` paths (e.g., `children*`) for every self-referential edge in the source graph.
+
+Concourse `1.0.x` provides both features; older Concourse servers provide neither. The third row of the table is the both-on case; the fourth row is the both-off case.
+
+Whichever paths a single `navigate()` cannot reach are gathered by a follow-up bulk-`select()` cleanup pass that walks the missing graph one round trip at a time. Two classes of edge always require the cleanup, regardless of server version: a cycle that alternates between two different field names (for example, a type `A` that links to `B` through a field named `bs` while `B` links back through a field named `as` &mdash; the `*` modifier can only repeat one field name), and a link whose target has been deleted. Against an older server, every self-referential edge also needs the cleanup, because the navigate-path set has had its `*` paths stripped.
+
+The third row's `1` falls out of both optimizations being in effect: the Command API combines the select and the navigate into one round trip, and the `*` modifier makes that single navigate cover an arbitrarily deep self-referential tree, so the cleanup pass has nothing to walk for a pure tree. A graph with alternating-field cycles still costs one cleanup round trip per level of the part `*` could not express.
+
+The fourth row's `2 + D` is the same calculation with both optimizations absent: two round trips for the separate select and navigate, plus one cleanup round trip per level of every self-referential edge (`+ D` for a tree of depth `D`). Non-cyclic graphs do not depend on `*` paths, so they pay only the Command-API cost: `2` round trips.
 
 ##### API Breaks and Deprecations
 * Removed the `CachingConcourse` infrastructure and the related `Runway.Builder` cache configuration. `Runway.Builder.cache(Cache<Long, Record>)` and `Runway.Builder.withCache(Cache<Long, Map<String, Set<Object>>>)` have been deleted along with the `com.cinchapi.runway.cache` package (`CachingConcourse`, `CachingConnectionPool`, `LeasingCache`, `NoOpLeasingCache`, `NoOpCache`). Connection-level data caching is removed in this release; the planned `prepare()`/`submit()` write transport made the per-method invalidation model untenable, and the implementation had latent invalidation bugs (e.g., missing overrides for `consolidate`, `link`, `unlink`, and several `clear` / `insert` variants). Callers that relied on `withCache(...)` should remove the configuration; the thread-local reservation API (`Runway#reserve()` / `Runway#unreserve()`) is unaffected. ([GH-81](https://github.com/cinchapi/runway/issues/81))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-#### Version 2.0.0 (May 19, 2026)
+#### Version 2.0.0 (May 20, 2026)
 
 ##### Command API
 This release adopts the Concourse Command API (`prepare()`/`submit()`), introduced in Concourse 1.0.0, to batch Runway's hottest read and write paths into the fewest possible server round trips. When the connected server is older than 1.0.0, Runway transparently falls back to the legacy per-call path.

--- a/src/test/java/com/cinchapi/runway/SaveRoundTripCountTest.java
+++ b/src/test/java/com/cinchapi/runway/SaveRoundTripCountTest.java
@@ -1,0 +1,315 @@
+/*
+ * Copyright (c) 2013-2026 Cinchapi Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.cinchapi.runway;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.cinchapi.common.reflect.Reflection;
+import com.cinchapi.concourse.Concourse;
+import com.cinchapi.concourse.ConnectionPool;
+import com.cinchapi.runway.CountingConcourseConnectionPool.CountingConcourse;
+
+/**
+ * Round-trip count regression tests for {@link Runway#save(Record...)} and
+ * {@link Runway#save(boolean, Record...)} when routed through the
+ * {@link com.cinchapi.runway.db.BatchSaver BatchSaver}.
+ * <p>
+ * Each test reflectively replaces the {@link Runway} connection pool with a
+ * {@link CountingConcourseConnectionPool}, performs one save, and asserts the
+ * exact number of {@code submit(CommandGroup)} round trips it issued. These
+ * tests lock in the {@code 2.0.0} contract that a save with no validation reads
+ * costs {@code 1} round trip and a save that needs at least one
+ * {@link Unique @Unique}-uniqueness check or a {@code preventStaleWrites} audit
+ * costs {@code 2}, regardless of how many records the save covers.
+ * </p>
+ *
+ * @author Jeff Nelson
+ */
+public class SaveRoundTripCountTest extends RunwayBaseClientServerTest {
+
+    @Override
+    protected void beforeTestRun() {
+        super.beforeTestRun();
+        Reflection.set("supportsBulkCommands", true, runway); // (authorized)
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that saving one {@link Record} with no
+     * {@link Unique @Unique} fields and {@code preventStaleWrites=false} costs
+     * exactly one server round trip through the
+     * {@link com.cinchapi.runway.db.BatchSaver BatchSaver}.
+     * <p>
+     * <strong>Start state:</strong> A {@link Runway} with bulk-commands forced
+     * on and a fresh {@link Plain} instance in memory.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Install a {@link CountingConcourseConnectionPool} on
+     * {@link #runway}.</li>
+     * <li>Reset the RPC counter and call {@code runway.save(record)}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The save returns {@code true} and exactly one
+     * {@code submit(CommandGroup)} round trip is observed &mdash; the single
+     * writes-plus-commit submission.
+     */
+    @Test
+    public void testSingleRecordWithoutValidationCostsOneRoundTrip() {
+        Plain record = new Plain("alpha", 7);
+        AtomicInteger rpcs = installCountingPool();
+        Assert.assertTrue(runway.save(record));
+        Assert.assertEquals(1, rpcs.get());
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that saving one {@link Record} with a
+     * {@link Unique @Unique} field costs exactly two server round trips through
+     * the {@link com.cinchapi.runway.db.BatchSaver BatchSaver}.
+     * <p>
+     * <strong>Start state:</strong> A {@link Runway} with bulk-commands forced
+     * on and a fresh {@link UniqueNamed} instance in memory.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Install a {@link CountingConcourseConnectionPool} on
+     * {@link #runway}.</li>
+     * <li>Reset the RPC counter and call {@code runway.save(record)}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The save returns {@code true} and exactly two
+     * {@code submit(CommandGroup)} round trips are observed &mdash; one for the
+     * writes-plus-uniqueness-{@code find} batch and one for the commit.
+     */
+    @Test
+    public void testSingleRecordWithUniqueCostsTwoRoundTrips() {
+        UniqueNamed record = new UniqueNamed("alpha");
+        AtomicInteger rpcs = installCountingPool();
+        Assert.assertTrue(runway.save(record));
+        Assert.assertEquals(2, rpcs.get());
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that re-saving a previously-loaded
+     * {@link Record} under {@code preventStaleWrites=true} costs exactly two
+     * server round trips through the {@link com.cinchapi.runway.db.BatchSaver
+     * BatchSaver}.
+     * <p>
+     * <strong>Start state:</strong> A {@link Plain} that has been saved and
+     * then reloaded, with one mutated field in memory.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Save and reload a {@link Plain} before instrumentation, so the record
+     * carries a non-zero checkpoint timestamp that arms the stale-data
+     * audit.</li>
+     * <li>Mutate the reloaded record.</li>
+     * <li>Install a {@link CountingConcourseConnectionPool} on
+     * {@link #runway}.</li>
+     * <li>Reset the RPC counter and call
+     * {@code runway.save(true, reloaded)}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The save returns {@code true} and exactly two
+     * {@code submit(CommandGroup)} round trips are observed &mdash; one for the
+     * audit-plus-writes batch and one for the commit.
+     */
+    @Test
+    public void testSingleRecordWithStaleCheckOnLoadedCostsTwoRoundTrips() {
+        Plain record = new Plain("alpha", 7);
+        Assert.assertTrue(runway.save(record));
+        Plain reloaded = runway.load(Plain.class, record.id());
+        reloaded.value = 8;
+        AtomicInteger rpcs = installCountingPool();
+        Assert.assertTrue(runway.save(true, reloaded));
+        Assert.assertEquals(2, rpcs.get());
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that re-saving a previously-loaded
+     * {@link Record} with both a {@link Unique @Unique} field and
+     * {@code preventStaleWrites=true} still costs exactly two server round
+     * trips &mdash; the audit and the uniqueness {@code find} ride along in the
+     * same {@code flushReads} batch as the writes.
+     * <p>
+     * <strong>Start state:</strong> A {@link UniqueNamed} that has been saved
+     * and reloaded, with no mutation (its name remains unique against itself).
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Save and reload a {@link UniqueNamed} before instrumentation.</li>
+     * <li>Install a {@link CountingConcourseConnectionPool} on
+     * {@link #runway}.</li>
+     * <li>Reset the RPC counter and call
+     * {@code runway.save(true, reloaded)}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The save returns {@code true} and exactly two
+     * {@code submit(CommandGroup)} round trips are observed.
+     */
+    @Test
+    public void testSingleRecordWithUniqueAndStaleCheckCostsTwoRoundTrips() {
+        UniqueNamed record = new UniqueNamed("alpha");
+        Assert.assertTrue(runway.save(record));
+        UniqueNamed reloaded = runway.load(UniqueNamed.class, record.id());
+        AtomicInteger rpcs = installCountingPool();
+        Assert.assertTrue(runway.save(true, reloaded));
+        Assert.assertEquals(2, rpcs.get());
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that a bulk save of {@code N}
+     * validation-free {@link Record Records} still costs exactly one server
+     * round trip &mdash; not {@code N} &mdash; through the
+     * {@link com.cinchapi.runway.db.BatchSaver BatchSaver}.
+     * <p>
+     * <strong>Start state:</strong> A {@link Runway} with bulk-commands forced
+     * on and ten fresh {@link Plain} instances in memory.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Install a {@link CountingConcourseConnectionPool} on
+     * {@link #runway}.</li>
+     * <li>Reset the RPC counter and call {@code runway.save(records...)}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The save returns {@code true} and exactly one
+     * {@code submit(CommandGroup)} round trip is observed regardless of how
+     * many records the call covers.
+     */
+    @Test
+    public void testBulkSaveWithoutValidationCostsOneRoundTrip() {
+        Plain[] records = new Plain[10];
+        for (int i = 0; i < records.length; i++) {
+            records[i] = new Plain("r" + i, i);
+        }
+        AtomicInteger rpcs = installCountingPool();
+        Assert.assertTrue(runway.save(records));
+        Assert.assertEquals(1, rpcs.get());
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that a bulk save of {@code N} {@link Record
+     * Records} each carrying a {@link Unique @Unique} field costs exactly two
+     * server round trips &mdash; not {@code 2 * N} &mdash; because every
+     * record's uniqueness {@code find} accumulates into a single
+     * {@code flushReads} batch alongside the writes.
+     * <p>
+     * <strong>Start state:</strong> Ten fresh {@link UniqueNamed} instances
+     * with distinct names.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Install a {@link CountingConcourseConnectionPool} on
+     * {@link #runway}.</li>
+     * <li>Reset the RPC counter and call {@code runway.save(records...)}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The save returns {@code true} and exactly two
+     * {@code submit(CommandGroup)} round trips are observed.
+     */
+    @Test
+    public void testBulkSaveWithUniqueCostsTwoRoundTrips() {
+        UniqueNamed[] records = new UniqueNamed[10];
+        for (int i = 0; i < records.length; i++) {
+            records[i] = new UniqueNamed("u" + i);
+        }
+        AtomicInteger rpcs = installCountingPool();
+        Assert.assertTrue(runway.save(records));
+        Assert.assertEquals(2, rpcs.get());
+    }
+
+    /**
+     * Reflectively replace {@link #runway runway's} connection pool with a
+     * {@link CountingConcourseConnectionPool} and return that pool's shared RPC
+     * counter, already reset to zero so the next save's round trips are the
+     * only ones tallied.
+     *
+     * @return the RPC counter that the swapped-in pool shares across every
+     *         connection it produces
+     */
+    private AtomicInteger installCountingPool() {
+        ConnectionPool pool = new CountingConcourseConnectionPool(
+                Concourse.connect("localhost", server.getClientPort(), "admin",
+                        "admin", environment));
+        Reflection.set("connections", pool, runway); // (authorized)
+        Concourse connection = pool.request();
+        AtomicInteger rpcs = ((CountingConcourse) connection).rpcs();
+        pool.release(connection);
+        rpcs.set(0);
+        return rpcs;
+    }
+
+    /**
+     * A minimal {@link Record} with no {@link Unique @Unique} fields, used to
+     * exercise the save path that needs no validation reads.
+     *
+     * @author Jeff Nelson
+     */
+    public static class Plain extends Record {
+
+        /**
+         * An arbitrary label.
+         */
+        String name;
+
+        /**
+         * An arbitrary integer value.
+         */
+        int value;
+
+        /**
+         * Construct a new instance.
+         *
+         * @param name the {@link #name} value
+         * @param value the {@link #value} value
+         */
+        public Plain(String name, int value) {
+            this.name = name;
+            this.value = value;
+        }
+
+    }
+
+    /**
+     * A {@link Record} with one {@link Unique @Unique} field, used to exercise
+     * the save path that adds a uniqueness {@code find} to the
+     * {@code flushReads} batch.
+     *
+     * @author Jeff Nelson
+     */
+    public static class UniqueNamed extends Record {
+
+        /**
+         * The unique name.
+         */
+        @Unique
+        String name;
+
+        /**
+         * Construct a new instance.
+         *
+         * @param name the {@link #name} value
+         */
+        public UniqueNamed(String name) {
+            this.name = name;
+        }
+
+    }
+
+}


### PR DESCRIPTION
## Summary
- Adds `SaveRoundTripCountTest` (6 cases) that asserts the 2.0.0 BatchSaver round-trip contract from the changelog: `1` round trip for saves with no validation reads, `2` for saves with `@Unique` and/or `preventStaleWrites=true`, both holding for bulk saves of N records. `CountingConcourseConnectionPool` was already counting `submit(CommandGroup)` for the load-path tests; this just lifts the same instrument onto the save path so the save claims have regression protection.
- Clarifies the 2.0.0 round-trip table in the changelog. The previous prose conflated the Command API and the `*` transitive modifier into one factor, which implied a 2.0.0 load on a 0.12.x server costs only `+1` round trip regardless of graph shape. The two are independent optimizations both gated on Concourse 1.0.0, and only the `1.0.x` row composes them; on the legacy fallback path Runway strips `*` paths from the navigate set, so every level of every self-referential edge falls through to the bulk-`select()` cleanup BFS. Adds the missing `2.0.0` / `0.12.x` row (`2` for non-cyclic, `2 + D` for self-referential trees), relabels the `1.0.x` row to name both optimizations it depends on, and rewrites the caveat paragraphs to decompose the two features and their interaction with the cleanup pass.
- Notes that untyped loads spanning `K` classes cost one round trip per class group, so the table's `1` applies only to typed loads and to untyped loads whose results all belong to a single class.

## Test plan
- [ ] `./gradlew test --tests com.cinchapi.runway.SaveRoundTripCountTest` — all 6 cases pass locally
- [ ] Re-read CHANGELOG.md diff and confirm the new prose matches the actual code paths in `BatchSaver.commit` / `BatchSaver.flushReads`, `Runway.$selectRecord` (`:1738-1751`), and `Runway.prefetchLinks` (`:2351-2366`)
- [ ] Spot-check that no other CHANGELOG entries were unintentionally touched
