### PR TITLE
GH-125: Route LoadRecordSelection through engine for scoped visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-#### Version 2.0.1 (TBD)
+#### Version 2.1.0 (TBD)
 * Fixed a bug where loading an access-controlled `Record` through an `Audience` (e.g., `Audience#load(Class, long)`) threw `UnsupportedOperationException` when the class's registered visibility `Scope` used a scoped navigation criteria (`Criteria.where().scope(prefix, inner)`). ([GH-125](https://github.com/cinchapi/runway/issues/125))
 
 #### Version 2.0.0 (May 20, 2026)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+#### Version 2.0.1 (TBD)
+* Fixed a bug where loading an access-controlled `Record` through an `Audience` (e.g., `Audience#load(Class, long)`) threw `UnsupportedOperationException` when the class's registered visibility `Scope` used a scoped navigation criteria (`Criteria.where().scope(prefix, inner)`). ([GH-125](https://github.com/cinchapi/runway/issues/125))
+
 #### Version 2.0.0 (May 20, 2026)
 
 ##### Command API

--- a/src/main/java/com/cinchapi/runway/DatabaseSelection.java
+++ b/src/main/java/com/cinchapi/runway/DatabaseSelection.java
@@ -21,6 +21,8 @@ import java.util.function.Predicate;
 
 import javax.annotation.Nullable;
 
+import com.cinchapi.ccl.grammar.ScopeSymbol;
+import com.cinchapi.ccl.grammar.Symbol;
 import com.cinchapi.concourse.lang.Criteria;
 import com.cinchapi.concourse.lang.paginate.Page;
 import com.cinchapi.concourse.lang.sort.Order;
@@ -52,6 +54,32 @@ abstract class DatabaseSelection<T extends Record> implements Selection<T> {
      */
     static boolean isNoFilter(Predicate<?> filter) {
         return filter == NO_FILTER;
+    }
+
+    /**
+     * Return {@code true} if {@code criteria} contains a scoped condition
+     * (i.e., a {@code prefix.(inner)} sub-tree) anywhere in its structure.
+     * <p>
+     * Scoped conditions require engine-side evaluation; the local CCL compiler
+     * throws {@link UnsupportedOperationException} when asked to evaluate one.
+     * Callers detect this up front so that {@link Criteria} carrying a scoped
+     * condition can be routed through the engine instead of through a local
+     * filter.
+     *
+     * @param criteria the {@link Criteria} to inspect
+     * @return {@code true} if {@code criteria} contains a scoped condition
+     */
+    static boolean isScopeBearing(Criteria criteria) {
+        for (Symbol symbol : criteria.symbols()) {
+            if(symbol instanceof ScopeSymbol) {
+                return true;
+            }
+            if(symbol instanceof Criteria
+                    && isScopeBearing((Criteria) symbol)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/com/cinchapi/runway/DatabaseSelection.java
+++ b/src/main/java/com/cinchapi/runway/DatabaseSelection.java
@@ -59,12 +59,6 @@ abstract class DatabaseSelection<T extends Record> implements Selection<T> {
     /**
      * Return {@code true} if {@code criteria} contains a scoped condition
      * (i.e., a {@code prefix.(inner)} sub-tree) anywhere in its structure.
-     * <p>
-     * Scoped conditions require engine-side evaluation; the local CCL compiler
-     * throws {@link UnsupportedOperationException} when asked to evaluate one.
-     * Callers detect this up front so that {@link Criteria} carrying a scoped
-     * condition can be routed through the engine instead of through a local
-     * filter.
      *
      * @param criteria the {@link Criteria} to inspect
      * @return {@code true} if {@code criteria} contains a scoped condition

--- a/src/main/java/com/cinchapi/runway/Record.java
+++ b/src/main/java/com/cinchapi/runway/Record.java
@@ -163,6 +163,9 @@ public abstract class Record implements Comparable<Record> {
      */
     public static <T extends Record> boolean isDatabaseResolvableCondition(
             Class<T> clazz, Criteria condition) {
+        if(DatabaseSelection.isScopeBearing(condition)) {
+            return true;
+        }
         Set<String> intrinsic = StaticAnalysis.instance().getKeys(clazz);
         Parser parser = Parsers.create(condition);
         for (String key : parser.analyze().keys()) {

--- a/src/main/java/com/cinchapi/runway/Record.java
+++ b/src/main/java/com/cinchapi/runway/Record.java
@@ -166,7 +166,8 @@ public abstract class Record implements Comparable<Record> {
         Set<String> intrinsic = StaticAnalysis.instance().getKeys(clazz);
         Parser parser = Parsers.create(condition);
         for (String key : parser.analyze().keys()) {
-            if(!Keys.isNavigationKey(key) && !intrinsic.contains(key)) {
+            if(!Keys.isNavigationKey(key) && !intrinsic.contains(key)
+                    && !IDENTIFIER_KEY.equals(key)) {
                 return false;
             }
         }

--- a/src/main/java/com/cinchapi/runway/Selection.java
+++ b/src/main/java/com/cinchapi/runway/Selection.java
@@ -124,9 +124,7 @@ public interface Selection<T extends Record> {
         if(resolved instanceof LoadRecordSelection) {
             if(DatabaseSelection.isScopeBearing(injected)) {
                 // Local CCL evaluation cannot honor same-destination
-                // semantics for a scoped condition, so route the load
-                // through a UniqueSelection anchored at $id$ so the engine
-                // evaluates the scoped predicate.
+                // semantics for a scoped condition.
                 LoadRecordSelection<T> load = (LoadRecordSelection<T>) resolved;
                 Criteria idMatch = Criteria.where().key(Record.IDENTIFIER_KEY)
                         .operator(Operator.EQUALS).value(load.id).build();

--- a/src/main/java/com/cinchapi/runway/Selection.java
+++ b/src/main/java/com/cinchapi/runway/Selection.java
@@ -142,8 +142,10 @@ public interface Selection<T extends Record> {
                 result.origin = selection;
                 return result;
             }
-            return withInjectedFilter(selection,
-                    record -> record.matches(injected));
+            else {
+                return withInjectedFilter(selection,
+                        record -> record.matches(injected));
+            }
         }
         else {
             resolved = resolved.duplicate();

--- a/src/main/java/com/cinchapi/runway/Selection.java
+++ b/src/main/java/com/cinchapi/runway/Selection.java
@@ -128,8 +128,11 @@ public interface Selection<T extends Record> {
                 LoadRecordSelection<T> load = (LoadRecordSelection<T>) resolved;
                 Criteria idMatch = Criteria.where().key(Record.IDENTIFIER_KEY)
                         .operator(Operator.EQUALS).value(load.id).build();
+                // any=true so a subclass record stored under load.id still
+                // resolves to its actual type; $id$ is unique across the
+                // hierarchy so this does not broaden the match.
                 DatabaseSelection.BuilderState<T> state = new DatabaseSelection.BuilderState<>(
-                        resolved.clazz, resolved.any);
+                        resolved.clazz, true);
                 state.unique = true;
                 state.criteria = Criteria.where().group(idMatch).and()
                         .group(injected).build();

--- a/src/main/java/com/cinchapi/runway/Selection.java
+++ b/src/main/java/com/cinchapi/runway/Selection.java
@@ -22,6 +22,7 @@ import java.util.function.Predicate;
 import com.cinchapi.concourse.lang.Criteria;
 import com.cinchapi.concourse.lang.paginate.Page;
 import com.cinchapi.concourse.lang.sort.Order;
+import com.cinchapi.concourse.thrift.Operator;
 
 /**
  * A {@link Selection} describes a single data retrieval operation against a
@@ -121,6 +122,25 @@ public interface Selection<T extends Record> {
         DatabaseSelection<T> resolved = (DatabaseSelection<T>) DatabaseSelection
                 .resolve(selection);
         if(resolved instanceof LoadRecordSelection) {
+            if(DatabaseSelection.isScopeBearing(injected)) {
+                // Local CCL evaluation cannot honor same-destination
+                // semantics for a scoped condition, so route the load
+                // through a UniqueSelection anchored at $id$ so the engine
+                // evaluates the scoped predicate.
+                LoadRecordSelection<T> load = (LoadRecordSelection<T>) resolved;
+                Criteria idMatch = Criteria.where().key(Record.IDENTIFIER_KEY)
+                        .operator(Operator.EQUALS).value(load.id).build();
+                DatabaseSelection.BuilderState<T> state = new DatabaseSelection.BuilderState<>(
+                        resolved.clazz, resolved.any);
+                state.unique = true;
+                state.criteria = Criteria.where().group(idMatch).and()
+                        .group(injected).build();
+                state.filter = resolved.filter;
+                state.realms = resolved.realms;
+                UniqueSelection<T> result = new UniqueSelection<>(state);
+                result.origin = selection;
+                return result;
+            }
             return withInjectedFilter(selection,
                     record -> record.matches(injected));
         }

--- a/src/main/java/com/cinchapi/runway/access/Scope.java
+++ b/src/main/java/com/cinchapi/runway/access/Scope.java
@@ -27,32 +27,25 @@ import com.google.common.collect.ImmutableSet;
 
 /**
  * Describes the visibility that an {@link Audience} has for a given
- * {@link Record} class, and knows how to apply that visibility to a
- * {@link Selection}.
+ * {@link Record} class.
  * <p>
- * A {@link Scope} pairs an engine-side rule for filtering loaded results with a
- * local rule for testing whether an individual {@link Record} falls within
- * visibility. Providers are registered via
+ * Providers are registered via
  * {@link AccessControl#registerVisibilityScope(Class, java.util.function.Function)}.
  * </p>
  * <p>
  * There are five variants:
  * </p>
  * <ul>
- * <li>{@link #unrestricted()} &mdash; the audience sees all records; no filter
- * or criteria is applied.</li>
- * <li>{@link #none()} &mdash; the audience sees no records; results are always
- * empty.</li>
+ * <li>{@link #unrestricted()} &mdash; the audience sees all records.</li>
+ * <li>{@link #none()} &mdash; the audience sees no records.</li>
  * <li>{@link #of(Criteria)} &mdash; visibility is expressed as a
- * {@link Criteria} that is pushed into the query and evaluated locally on each
- * per-record visibility check.</li>
+ * {@link Criteria}.</li>
  * <li>{@link #hybrid(Criteria, Audience)} /
  * {@link #hybrid(Criteria, Predicate)} &mdash; visibility is expressed as a
- * {@link Criteria} for database loads and a separate {@link Predicate} for
- * per-record visibility checks; intended as an escape hatch for {@link Criteria
- * Criterias} that use scoped navigation.</li>
- * <li>{@link #unsupported()} &mdash; visibility cannot be expressed as a
- * database constraint for this combination.</li>
+ * {@link Criteria} together with an independent per-record
+ * {@link Predicate}.</li>
+ * <li>{@link #unsupported()} &mdash; visibility cannot be expressed for this
+ * combination.</li>
  * </ul>
  *
  * @author Jeff Nelson
@@ -83,37 +76,29 @@ public abstract class Scope {
     }
 
     /**
-     * Return a {@link Scope} that uses {@code criteria} for database loads and
-     * the {@link Audience Audience's} discoverability check
-     * ({@link AccessControl#$isDiscoverableBy(Audience)}, or
+     * Return a {@link Scope} whose visibility is expressed by {@code criteria}
+     * and whose per-record test is the {@link Audience Audience's}
+     * discoverability ({@link AccessControl#$isDiscoverableBy(Audience)}, or
      * {@link AccessControl#$isDiscoverableByAnonymous()} for an anonymous
-     * {@link Audience}) for per-record visibility checks.
+     * {@link Audience}).
      * <p>
-     * Use this overload (or its {@link #hybrid(Criteria, Predicate)} sibling)
-     * in place of {@link #of(Criteria)} when {@code criteria} contains a scoped
-     * navigation clause such as {@code Criteria.where().scope(prefix, inner)}.
-     * {@link #of(Criteria)} uses the same {@link Criteria} for both database
-     * loads and per-record checks, but the per-record path resolves the
-     * {@link Criteria} locally and the local resolver cannot honor scoped
-     * same-destination semantics. The hybrid form holds the {@link Predicate}
-     * separately so the per-record path never asks the local resolver to
-     * evaluate the scoped {@link Criteria}.
+     * Suitable when {@code criteria} is not locally evaluable on a
+     * {@link Record} &mdash; for example, when it contains a scoped navigation
+     * clause such as {@code Criteria.where().scope(prefix, inner)}.
      * </p>
      * <p>
      * <strong>Caller's responsibility:</strong> {@code criteria} and the
      * default discoverability check must produce logically equivalent results
-     * for {@code audience}. When they diverge, the engine path and the local
-     * path admit different records, which is a visibility hole. Use
+     * for {@code audience}, or visibility becomes inconsistent. Use
      * {@link #hybrid(Criteria, Predicate)} to supply an explicit
      * {@link Predicate} when discoverability is not an accurate mirror of
      * {@code criteria}.
      * </p>
-     * 
+     *
      * @param criteria the {@link Criteria} that limits which records are
      *            visible to {@code audience}
      * @param audience the {@link Audience} whose discoverability check backs
      *            the per-record predicate
-     *
      * @return a new hybrid {@link Scope}
      */
     public static Scope hybrid(Criteria criteria, Audience audience) {
@@ -130,25 +115,18 @@ public abstract class Scope {
     }
 
     /**
-     * Return a {@link Scope} that uses {@code criteria} for database loads and
-     * {@code predicate} for per-record visibility checks.
+     * Return a {@link Scope} whose visibility is expressed by {@code criteria}
+     * and whose per-record test is {@code predicate}.
      * <p>
-     * Use this overload (or its {@link #hybrid(Criteria, Audience)} sibling) in
-     * place of {@link #of(Criteria)} when {@code criteria} contains a scoped
-     * navigation clause such as {@code Criteria.where().scope(prefix, inner)}.
-     * {@link #of(Criteria)} uses the same {@link Criteria} for both database
-     * loads and per-record checks, but the per-record path resolves the
-     * {@link Criteria} locally and the local resolver cannot honor scoped
-     * same-destination semantics. The hybrid form holds the {@link Predicate}
-     * separately so the per-record path never asks the local resolver to
-     * evaluate the scoped {@link Criteria}.
+     * Suitable when {@code criteria} is not locally evaluable on a
+     * {@link Record} &mdash; for example, when it contains a scoped navigation
+     * clause such as {@code Criteria.where().scope(prefix, inner)}.
      * </p>
      * <p>
      * <strong>Caller's responsibility:</strong> {@code criteria} and
      * {@code predicate} must produce logically equivalent results for the
-     * {@link Audience} this {@link Scope} is being constructed for. When they
-     * diverge, the engine path and the local path admit different records,
-     * which is a visibility hole.
+     * {@link Audience} this {@link Scope} is being constructed for, or
+     * visibility becomes inconsistent.
      * </p>
      *
      * @param criteria the {@link Criteria} that limits which records are
@@ -253,29 +231,26 @@ public abstract class Scope {
     }
 
     /**
-     * A {@link Scope} that pairs a {@link Criteria} used for database loads
-     * with a separate {@link Predicate} used for per-record visibility checks.
-     * The two paths are independent, which is what allows scoped navigation
-     * {@link Criteria Criterias} (uncompilable by the local resolver) to be
-     * used as visibility rules.
+     * A {@link Scope} whose visibility is expressed by a {@link Criteria}
+     * together with an independent per-record {@link Predicate}.
      */
     @Immutable
     private static final class Hybrid extends Scope {
 
         /**
-         * The visibility {@link Criteria} for database loads.
+         * The visibility {@link Criteria}.
          */
         private final Criteria criteria;
 
         /**
-         * The visibility {@link Predicate} for per-record checks.
+         * The per-record visibility {@link Predicate}.
          */
         private final Predicate<? super Record> localTest;
 
         /**
          * Construct a new {@link Hybrid}.
          *
-         * @param criteria the database-side {@link Criteria}
+         * @param criteria the visibility {@link Criteria}
          * @param localTest the per-record {@link Predicate}
          */
         private Hybrid(Criteria criteria, Predicate<? super Record> localTest) {

--- a/src/main/java/com/cinchapi/runway/access/Scope.java
+++ b/src/main/java/com/cinchapi/runway/access/Scope.java
@@ -67,17 +67,11 @@ public abstract class Scope {
      * Return a {@link Scope} whose visibility is expressed by the given
      * {@link Criteria}.
      * <p>
-     * <strong>NOTE:</strong> {@code criteria} must be locally evaluable on a
-     * {@link Record}, since {@link #test(Record)} delegates to
-     * {@link Record#matches(Criteria)}. Criteria that the local CCL compiler
-     * cannot evaluate &mdash; most notably scoped navigation clauses such as
-     * {@code Criteria.where().scope(prefix, inner)} &mdash; will succeed on the
-     * query path but throw {@link UnsupportedOperationException} when
-     * {@link #test(Record)} is invoked (e.g., during
-     * {@link Audience#frame(java.util.Collection, Record)}). Use
+     * {@code criteria} must be locally evaluable on a {@link Record}; use
      * {@link #hybrid(Criteria, Audience)} or
-     * {@link #hybrid(Criteria, java.util.function.Predicate)} for those shapes
-     * so the per-record check is held separately from the query criteria.
+     * {@link #hybrid(Criteria, Predicate)} when {@code criteria} contains a
+     * scoped navigation clause such as
+     * {@code Criteria.where().scope(prefix, inner)}.
      * </p>
      *
      * @param criteria the {@link Criteria} that limits which records are

--- a/src/main/java/com/cinchapi/runway/access/Scope.java
+++ b/src/main/java/com/cinchapi/runway/access/Scope.java
@@ -66,6 +66,19 @@ public abstract class Scope {
     /**
      * Return a {@link Scope} whose visibility is expressed by the given
      * {@link Criteria}.
+     * <p>
+     * <strong>NOTE:</strong> {@code criteria} must be locally evaluable on a
+     * {@link Record}, since {@link #test(Record)} delegates to
+     * {@link Record#matches(Criteria)}. Criteria that the local CCL compiler
+     * cannot evaluate &mdash; most notably scoped navigation clauses such as
+     * {@code Criteria.where().scope(prefix, inner)} &mdash; will succeed on the
+     * query path but throw {@link UnsupportedOperationException} when
+     * {@link #test(Record)} is invoked (e.g., during
+     * {@link Audience#frame(java.util.Collection, Record)}). Use
+     * {@link #hybrid(Criteria, Audience)} or
+     * {@link #hybrid(Criteria, java.util.function.Predicate)} for those shapes
+     * so the per-record check is held separately from the query criteria.
+     * </p>
      *
      * @param criteria the {@link Criteria} that limits which records are
      *            visible to the {@link Audience}

--- a/src/main/java/com/cinchapi/runway/access/Scope.java
+++ b/src/main/java/com/cinchapi/runway/access/Scope.java
@@ -15,6 +15,8 @@
  */
 package com.cinchapi.runway.access;
 
+import java.util.function.Predicate;
+
 import javax.annotation.concurrent.Immutable;
 
 import com.cinchapi.common.reflect.Reflection;
@@ -28,12 +30,13 @@ import com.google.common.collect.ImmutableSet;
  * {@link Record} class, and knows how to apply that visibility to a
  * {@link Selection}.
  * <p>
- * A {@link Scope} is obtained by registering a provider with
- * {@link AccessControl#registerVisibilityScope(Class, java.util.function.Function)}
- * and is resolved at query time by {@link Audience#select(Selection[])}.
+ * A {@link Scope} pairs an engine-side rule for filtering loaded results with a
+ * local rule for testing whether an individual {@link Record} falls within
+ * visibility. Providers are registered via
+ * {@link AccessControl#registerVisibilityScope(Class, java.util.function.Function)}.
  * </p>
  * <p>
- * There are four variants:
+ * There are five variants:
  * </p>
  * <ul>
  * <li>{@link #unrestricted()} &mdash; the audience sees all records; no filter
@@ -41,7 +44,13 @@ import com.google.common.collect.ImmutableSet;
  * <li>{@link #none()} &mdash; the audience sees no records; results are always
  * empty.</li>
  * <li>{@link #of(Criteria)} &mdash; visibility is expressed as a
- * {@link Criteria} that is pushed into the query.</li>
+ * {@link Criteria} that is pushed into the query and evaluated locally on each
+ * per-record visibility check.</li>
+ * <li>{@link #hybrid(Audience, Criteria)} /
+ * {@link #hybrid(Criteria, Predicate)} &mdash; visibility is expressed as a
+ * {@link Criteria} for database loads and a separate {@link Predicate} for
+ * per-record visibility checks; intended as an escape hatch for {@link Criteria
+ * Criterias} that use scoped navigation.</li>
  * <li>{@link #unsupported()} &mdash; visibility cannot be expressed as a
  * database constraint for this combination.</li>
  * </ul>
@@ -71,6 +80,84 @@ public abstract class Scope {
      */
     public static Scope of(Criteria criteria) {
         return new CriteriaBased(criteria);
+    }
+
+    /**
+     * Return a {@link Scope} that uses {@code criteria} for database loads and
+     * the {@link Audience Audience's} discoverability check
+     * ({@link AccessControl#$isDiscoverableBy(Audience)}, or
+     * {@link AccessControl#$isDiscoverableByAnonymous()} for an anonymous
+     * {@link Audience}) for per-record visibility checks.
+     * <p>
+     * Use this overload (or its {@link #hybrid(Criteria, Predicate)} sibling)
+     * in place of {@link #of(Criteria)} when {@code criteria} contains a scoped
+     * navigation clause such as {@code Criteria.where().scope(prefix, inner)}.
+     * {@link #of(Criteria)} uses the same {@link Criteria} for both database
+     * loads and per-record checks, but the per-record path resolves the
+     * {@link Criteria} locally and the local resolver cannot honor scoped
+     * same-destination semantics. The hybrid form holds the {@link Predicate}
+     * separately so the per-record path never asks the local resolver to
+     * evaluate the scoped {@link Criteria}.
+     * </p>
+     * <p>
+     * <strong>Caller's responsibility:</strong> {@code criteria} and the
+     * default discoverability check must produce logically equivalent results
+     * for {@code audience}. When they diverge, the engine path and the local
+     * path admit different records, which is a visibility hole. Use
+     * {@link #hybrid(Criteria, Predicate)} to supply an explicit
+     * {@link Predicate} when discoverability is not an accurate mirror of
+     * {@code criteria}.
+     * </p>
+     *
+     * @param audience the {@link Audience} whose discoverability check backs
+     *            the per-record predicate
+     * @param criteria the {@link Criteria} that limits which records are
+     *            visible to {@code audience}
+     * @return a new hybrid {@link Scope}
+     */
+    public static Scope hybrid(Audience audience, Criteria criteria) {
+        Predicate<? super Record> defaultPredicate = record -> {
+            if(record instanceof AccessControl) {
+                AccessControl subject = (AccessControl) record;
+                return audience instanceof Anonymous
+                        ? subject.$isDiscoverableByAnonymous()
+                        : subject.$isDiscoverableBy(audience);
+            }
+            return true;
+        };
+        return new Hybrid(criteria, defaultPredicate);
+    }
+
+    /**
+     * Return a {@link Scope} that uses {@code criteria} for database loads and
+     * {@code predicate} for per-record visibility checks.
+     * <p>
+     * Use this overload (or its {@link #hybrid(Audience, Criteria)} sibling) in
+     * place of {@link #of(Criteria)} when {@code criteria} contains a scoped
+     * navigation clause such as {@code Criteria.where().scope(prefix, inner)}.
+     * {@link #of(Criteria)} uses the same {@link Criteria} for both database
+     * loads and per-record checks, but the per-record path resolves the
+     * {@link Criteria} locally and the local resolver cannot honor scoped
+     * same-destination semantics. The hybrid form holds the {@link Predicate}
+     * separately so the per-record path never asks the local resolver to
+     * evaluate the scoped {@link Criteria}.
+     * </p>
+     * <p>
+     * <strong>Caller's responsibility:</strong> {@code criteria} and
+     * {@code predicate} must produce logically equivalent results for the
+     * {@link Audience} this {@link Scope} is being constructed for. When they
+     * diverge, the engine path and the local path admit different records,
+     * which is a visibility hole.
+     * </p>
+     *
+     * @param criteria the {@link Criteria} that limits which records are
+     *            visible to the {@link Audience}
+     * @param predicate the per-record visibility {@link Predicate}
+     * @return a new hybrid {@link Scope}
+     */
+    public static Scope hybrid(Criteria criteria,
+            Predicate<? super Record> predicate) {
+        return new Hybrid(criteria, predicate);
     }
 
     /**
@@ -161,6 +248,55 @@ public abstract class Scope {
         @Override
         public boolean test(Record record) {
             return record.matches(criteria);
+        }
+    }
+
+    /**
+     * A {@link Scope} that pairs a {@link Criteria} used for database loads
+     * with a separate {@link Predicate} used for per-record visibility checks.
+     * The two paths are independent, which is what allows scoped navigation
+     * {@link Criteria Criterias} (uncompilable by the local resolver) to be
+     * used as visibility rules.
+     */
+    @Immutable
+    private static final class Hybrid extends Scope {
+
+        /**
+         * The visibility {@link Criteria} for database loads.
+         */
+        private final Criteria criteria;
+
+        /**
+         * The visibility {@link Predicate} for per-record checks.
+         */
+        private final Predicate<? super Record> localTest;
+
+        /**
+         * Construct a new {@link Hybrid}.
+         *
+         * @param criteria the database-side {@link Criteria}
+         * @param localTest the per-record {@link Predicate}
+         */
+        private Hybrid(Criteria criteria, Predicate<? super Record> localTest) {
+            this.criteria = criteria;
+            this.localTest = localTest;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public Selection<?> apply(Selection<?> selection) {
+            return Selection.withInjectedCriteria((Selection<Record>) selection,
+                    criteria);
+        }
+
+        @Override
+        public boolean isApplicable() {
+            return true;
+        }
+
+        @Override
+        public boolean test(Record record) {
+            return localTest.test(record);
         }
     }
 

--- a/src/main/java/com/cinchapi/runway/access/Scope.java
+++ b/src/main/java/com/cinchapi/runway/access/Scope.java
@@ -46,7 +46,7 @@ import com.google.common.collect.ImmutableSet;
  * <li>{@link #of(Criteria)} &mdash; visibility is expressed as a
  * {@link Criteria} that is pushed into the query and evaluated locally on each
  * per-record visibility check.</li>
- * <li>{@link #hybrid(Audience, Criteria)} /
+ * <li>{@link #hybrid(Criteria, Audience)} /
  * {@link #hybrid(Criteria, Predicate)} &mdash; visibility is expressed as a
  * {@link Criteria} for database loads and a separate {@link Predicate} for
  * per-record visibility checks; intended as an escape hatch for {@link Criteria
@@ -108,14 +108,15 @@ public abstract class Scope {
      * {@link Predicate} when discoverability is not an accurate mirror of
      * {@code criteria}.
      * </p>
-     *
-     * @param audience the {@link Audience} whose discoverability check backs
-     *            the per-record predicate
+     * 
      * @param criteria the {@link Criteria} that limits which records are
      *            visible to {@code audience}
+     * @param audience the {@link Audience} whose discoverability check backs
+     *            the per-record predicate
+     *
      * @return a new hybrid {@link Scope}
      */
-    public static Scope hybrid(Audience audience, Criteria criteria) {
+    public static Scope hybrid(Criteria criteria, Audience audience) {
         Predicate<? super Record> defaultPredicate = record -> {
             if(record instanceof AccessControl) {
                 AccessControl subject = (AccessControl) record;
@@ -132,7 +133,7 @@ public abstract class Scope {
      * Return a {@link Scope} that uses {@code criteria} for database loads and
      * {@code predicate} for per-record visibility checks.
      * <p>
-     * Use this overload (or its {@link #hybrid(Audience, Criteria)} sibling) in
+     * Use this overload (or its {@link #hybrid(Criteria, Audience)} sibling) in
      * place of {@link #of(Criteria)} when {@code criteria} contains a scoped
      * navigation clause such as {@code Criteria.where().scope(prefix, inner)}.
      * {@link #of(Criteria)} uses the same {@link Criteria} for both database

--- a/src/test/java/com/cinchapi/runway/SelectionWithInjectedCriteriaTest.java
+++ b/src/test/java/com/cinchapi/runway/SelectionWithInjectedCriteriaTest.java
@@ -428,7 +428,6 @@ public class SelectionWithInjectedCriteriaTest {
     /**
      * A simple {@link Record} subclass for testing.
      */
-    static class TestRecord extends Record {} // empty — used only for type
-                                              // checking
+    static class TestRecord extends Record {}
 
 }

--- a/src/test/java/com/cinchapi/runway/SelectionWithInjectedCriteriaTest.java
+++ b/src/test/java/com/cinchapi/runway/SelectionWithInjectedCriteriaTest.java
@@ -426,6 +426,84 @@ public class SelectionWithInjectedCriteriaTest {
     }
 
     /**
+     * <strong>Goal:</strong> Verify that the {@link UniqueSelection} produced
+     * by promoting a {@link LoadRecordSelection} on the scope-bearing path
+     * carries a {@link Criteria} that
+     * {@link Record#isDatabaseResolvableCondition} accepts. Without this
+     * guarantee, {@code $selectCriteria} falls back to
+     * {@code filter()}/{@code filterAny()}, which calls
+     * {@link Record#matches(Criteria)} on the scope-bearing criteria and throws
+     * {@link UnsupportedOperationException} at runtime.
+     * <p>
+     * <strong>Start state:</strong> No prior state needed.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Build a {@link LoadRecordSelection} via {@code id(42L)}.</li>
+     * <li>Build a scope-bearing {@link Criteria}.</li>
+     * <li>Call {@link Selection#withInjectedCriteria}.</li>
+     * <li>Test the promoted {@link UniqueSelection}'s criteria against
+     * {@link Record#isDatabaseResolvableCondition}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> {@link Record#isDatabaseResolvableCondition}
+     * returns {@code true}.
+     */
+    @Test
+    public void testLoadRecordSelectionWithScopedCriteriaPromotedCriteriaIsDatabaseResolvable() {
+        Criteria scoped = Criteria
+                .where().scope("parent.children", Criteria.where()
+                        .key("user.userId").operator(Operator.EQUALS).value(7L))
+                .build();
+        Selection<TestRecord> sel = Selection.of(TestRecord.class).id(42L)
+                .build();
+        Selection<TestRecord> result = Selection.withInjectedCriteria(sel,
+                scoped);
+        UniqueSelection<TestRecord> unique = (UniqueSelection<TestRecord>) result;
+        Assert.assertTrue(Record.isDatabaseResolvableCondition(TestRecord.class,
+                unique.criteria));
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that promoting a
+     * {@link LoadRecordSelection} built from {@code Selection.of(...)} (i.e.,
+     * {@code any=false}) on the scope-bearing path produces a
+     * {@link UniqueSelection} with {@code any=true}. The promoted selection
+     * runs through {@code $selectCriteria}, which wraps with {@code forClass}
+     * when {@code any=false} and excludes records stored under a subclass
+     * section; setting {@code any=true} keeps subclass-by-id resolution
+     * working.
+     * <p>
+     * <strong>Start state:</strong> No prior state needed.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Build a {@link LoadRecordSelection} via
+     * {@code Selection.of(...).id(42L)} so the input {@code any} is
+     * {@code false}.</li>
+     * <li>Apply a scope-bearing visibility {@link Criteria} via
+     * {@link Selection#withInjectedCriteria}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The result is a {@link UniqueSelection} with
+     * {@code any=true}.
+     */
+    @Test
+    public void testLoadRecordSelectionWithScopedCriteriaPromotionForcesAnyTrue() {
+        Criteria scoped = Criteria
+                .where().scope("parent.children", Criteria.where()
+                        .key("user.userId").operator(Operator.EQUALS).value(7L))
+                .build();
+        Selection<TestRecord> sel = Selection.of(TestRecord.class).id(42L)
+                .build();
+        Selection<TestRecord> result = Selection.withInjectedCriteria(sel,
+                scoped);
+        Assert.assertTrue(result instanceof UniqueSelection);
+        DatabaseSelection<TestRecord> db = (DatabaseSelection<TestRecord>) result;
+        Assert.assertTrue(db.any);
+    }
+
+    /**
      * A simple {@link Record} subclass for testing.
      */
     static class TestRecord extends Record {}

--- a/src/test/java/com/cinchapi/runway/SelectionWithInjectedCriteriaTest.java
+++ b/src/test/java/com/cinchapi/runway/SelectionWithInjectedCriteriaTest.java
@@ -15,6 +15,8 @@
  */
 package com.cinchapi.runway;
 
+import java.util.function.Predicate;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -251,25 +253,30 @@ public class SelectionWithInjectedCriteriaTest {
     /**
      * <strong>Goal:</strong> Verify that injecting a scope-bearing visibility
      * {@link Criteria} into a {@link LoadRecordSelection} produces a
-     * {@link UniqueSelection} (not a {@link LoadRecordSelection}) so that the
-     * scoped condition is evaluated by the engine. The local CCL compiler
-     * cannot honor same-destination semantics across a navigation prefix and
-     * throws {@link UnsupportedOperationException} when asked to, so the
-     * filter-based path that {@link LoadRecordSelection} otherwise takes is
-     * unavailable for this {@link Criteria} shape.
+     * {@link UniqueSelection} (not a {@link LoadRecordSelection}) whose
+     * criteria is a freshly constructed {@code $id$ = id AND injected} that
+     * still carries the scoped sub-tree, so the engine evaluates the scoped
+     * condition. The local CCL compiler cannot honor same-destination semantics
+     * across a navigation prefix and throws
+     * {@link UnsupportedOperationException} when asked to, so the filter-based
+     * path that {@link LoadRecordSelection} otherwise takes is unavailable for
+     * this {@link Criteria} shape.
      * <p>
      * <strong>Start state:</strong> No prior state needed.
      * <p>
      * <strong>Workflow:</strong>
      * <ul>
-     * <li>Build a {@link LoadRecordSelection} via {@code id(...)}.</li>
+     * <li>Build a {@link LoadRecordSelection} via {@code id(42L)}.</li>
      * <li>Build a {@link Criteria} containing a {@code scope(prefix, inner)}
      * clause.</li>
      * <li>Call {@link Selection#withInjectedCriteria}.</li>
      * </ul>
      * <p>
-     * <strong>Expected:</strong> The result is a {@link UniqueSelection} (not a
-     * {@link LoadRecordSelection}); its criteria is non-null.
+     * <strong>Expected:</strong> The result is a {@link UniqueSelection} whose
+     * criteria is a new instance distinct from the injected one, whose CCL
+     * anchors on {@link Record#IDENTIFIER_KEY} bound to {@code 42}, and which
+     * still reports as {@link DatabaseSelection#isScopeBearing} so the engine
+     * sees the scoped sub-tree.
      */
     @Test
     public void testLoadRecordSelectionWithScopedCriteriaBecomesUniqueSelection() {
@@ -284,7 +291,11 @@ public class SelectionWithInjectedCriteriaTest {
         Assert.assertFalse(result instanceof LoadRecordSelection);
         Assert.assertTrue(result instanceof UniqueSelection);
         UniqueSelection<TestRecord> unique = (UniqueSelection<TestRecord>) result;
-        Assert.assertNotNull(unique.criteria);
+        Assert.assertNotSame(scoped, unique.criteria);
+        String ccl = unique.criteria.ccl();
+        Assert.assertTrue(ccl.contains(Record.IDENTIFIER_KEY));
+        Assert.assertTrue(ccl.contains("42"));
+        Assert.assertTrue(DatabaseSelection.isScopeBearing(unique.criteria));
     }
 
     /**
@@ -326,21 +337,24 @@ public class SelectionWithInjectedCriteriaTest {
      * detected even when it is nested inside a {@code group(...)} clause that
      * is conjoined with another condition &mdash; the engine still needs to
      * evaluate the scoped sub-tree, so the {@link LoadRecordSelection} must be
-     * promoted to a {@link UniqueSelection}.
+     * promoted to a {@link UniqueSelection} whose criteria is a fresh
+     * {@code $id$ = id AND injected} that still carries the nested scope.
      * <p>
      * <strong>Start state:</strong> No prior state needed.
      * <p>
      * <strong>Workflow:</strong>
      * <ul>
-     * <li>Build a {@link LoadRecordSelection} via {@code id(...)}.</li>
+     * <li>Build a {@link LoadRecordSelection} via {@code id(42L)}.</li>
      * <li>Build a {@link Criteria} of the form
      * {@code (scope(prefix, inner)) AND key = value}.</li>
      * <li>Call {@link Selection#withInjectedCriteria}.</li>
      * </ul>
      * <p>
-     * <strong>Expected:</strong> The result is a {@link UniqueSelection},
-     * because the scoped sub-tree was discovered during the recursive
-     * inspection of the injected {@link Criteria}.
+     * <strong>Expected:</strong> The result is a {@link UniqueSelection}, its
+     * criteria is a new instance distinct from the injected one, the CCL
+     * anchors on {@link Record#IDENTIFIER_KEY} bound to {@code 42}, and
+     * {@link DatabaseSelection#isScopeBearing} still reports {@code true} so
+     * the recursive inspection caught the nested scope.
      */
     @Test
     public void testLoadRecordSelectionDetectsNestedScopedCriteria() {
@@ -356,6 +370,59 @@ public class SelectionWithInjectedCriteriaTest {
                 nested);
         Assert.assertFalse(result instanceof LoadRecordSelection);
         Assert.assertTrue(result instanceof UniqueSelection);
+        UniqueSelection<TestRecord> unique = (UniqueSelection<TestRecord>) result;
+        Assert.assertNotSame(nested, unique.criteria);
+        String ccl = unique.criteria.ccl();
+        Assert.assertTrue(ccl.contains(Record.IDENTIFIER_KEY));
+        Assert.assertTrue(ccl.contains("42"));
+        Assert.assertTrue(DatabaseSelection.isScopeBearing(unique.criteria));
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that promoting a
+     * {@link LoadRecordSelection} to a {@link UniqueSelection} on the
+     * scope-bearing path preserves the {@code any} flag, the {@link Realms}
+     * filter, and any client-side {@link Predicate} that was already attached
+     * to the load. The new {@link UniqueSelection} carries the engine-side
+     * criteria, but the orthogonal post-selection state (realms scoping,
+     * hierarchy inclusion, local predicate) must survive intact.
+     * <p>
+     * <strong>Start state:</strong> No prior state needed.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Build a {@link LoadRecordSelection} via
+     * {@code ofAny(...).id(42L).realms(...)}.</li>
+     * <li>Wrap with {@link Selection#withInjectedFilter} to attach a
+     * client-side predicate (the {@code id(...)} builder does not expose
+     * {@code filter(...)} directly).</li>
+     * <li>Apply a scope-bearing visibility {@link Criteria} via
+     * {@link Selection#withInjectedCriteria}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The result is a {@link UniqueSelection} with
+     * {@code any == true}, the same {@link Realms} instance, and a filter that
+     * is no longer the {@code NO_FILTER} sentinel (proving the original
+     * predicate survived the conversion).
+     */
+    @Test
+    public void testLoadRecordSelectionWithScopedCriteriaPreservesFilterRealmsAndAny() {
+        Criteria scoped = Criteria
+                .where().scope("parent.children", Criteria.where()
+                        .key("user.userId").operator(Operator.EQUALS).value(7L))
+                .build();
+        Realms realms = Realms.only("test-realm");
+        Predicate<TestRecord> filter = r -> true;
+        Selection<TestRecord> sel = Selection.ofAny(TestRecord.class).id(42L)
+                .realms(realms).build();
+        sel = Selection.withInjectedFilter(sel, filter);
+        Selection<TestRecord> result = Selection.withInjectedCriteria(sel,
+                scoped);
+        Assert.assertTrue(result instanceof UniqueSelection);
+        DatabaseSelection<TestRecord> db = (DatabaseSelection<TestRecord>) result;
+        Assert.assertTrue(db.any);
+        Assert.assertSame(realms, db.realms);
+        Assert.assertFalse(DatabaseSelection.isNoFilter(db.filter));
     }
 
     /**

--- a/src/test/java/com/cinchapi/runway/SelectionWithInjectedCriteriaTest.java
+++ b/src/test/java/com/cinchapi/runway/SelectionWithInjectedCriteriaTest.java
@@ -249,6 +249,116 @@ public class SelectionWithInjectedCriteriaTest {
     }
 
     /**
+     * <strong>Goal:</strong> Verify that injecting a scope-bearing visibility
+     * {@link Criteria} into a {@link LoadRecordSelection} produces a
+     * {@link UniqueSelection} (not a {@link LoadRecordSelection}) so that the
+     * scoped condition is evaluated by the engine. The local CCL compiler
+     * cannot honor same-destination semantics across a navigation prefix and
+     * throws {@link UnsupportedOperationException} when asked to, so the
+     * filter-based path that {@link LoadRecordSelection} otherwise takes is
+     * unavailable for this {@link Criteria} shape.
+     * <p>
+     * <strong>Start state:</strong> No prior state needed.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Build a {@link LoadRecordSelection} via {@code id(...)}.</li>
+     * <li>Build a {@link Criteria} containing a {@code scope(prefix, inner)}
+     * clause.</li>
+     * <li>Call {@link Selection#withInjectedCriteria}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The result is a {@link UniqueSelection} (not a
+     * {@link LoadRecordSelection}); its criteria is non-null.
+     */
+    @Test
+    public void testLoadRecordSelectionWithScopedCriteriaBecomesUniqueSelection() {
+        Criteria scoped = Criteria
+                .where().scope("parent.children", Criteria.where()
+                        .key("user.userId").operator(Operator.EQUALS).value(7L))
+                .build();
+        Selection<TestRecord> sel = Selection.of(TestRecord.class).id(42L)
+                .build();
+        Selection<TestRecord> result = Selection.withInjectedCriteria(sel,
+                scoped);
+        Assert.assertFalse(result instanceof LoadRecordSelection);
+        Assert.assertTrue(result instanceof UniqueSelection);
+        UniqueSelection<TestRecord> unique = (UniqueSelection<TestRecord>) result;
+        Assert.assertNotNull(unique.criteria);
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that injecting a non-scope-bearing
+     * visibility {@link Criteria} into a {@link LoadRecordSelection} preserves
+     * the existing local-filter path. The local CCL compiler can evaluate such
+     * conditions correctly, so no conversion is needed and the single-record
+     * fetch by id is retained.
+     * <p>
+     * <strong>Start state:</strong> No prior state needed.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Build a {@link LoadRecordSelection} via {@code id(...)}.</li>
+     * <li>Build a simple key/value {@link Criteria} with no scoped
+     * condition.</li>
+     * <li>Call {@link Selection#withInjectedCriteria}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The result is still a
+     * {@link LoadRecordSelection}; its filter has been composed with the
+     * visibility predicate and is no longer the {@code NO_FILTER} sentinel.
+     */
+    @Test
+    public void testLoadRecordSelectionWithSimpleCriteriaKeepsLocalFilter() {
+        Criteria visibility = Criteria.where().key("owner")
+                .operator(Operator.EQUALS).value(42L).build();
+        Selection<TestRecord> sel = Selection.of(TestRecord.class).id(42L)
+                .build();
+        Selection<TestRecord> result = Selection.withInjectedCriteria(sel,
+                visibility);
+        Assert.assertTrue(result instanceof LoadRecordSelection);
+        DatabaseSelection<TestRecord> db = (DatabaseSelection<TestRecord>) result;
+        Assert.assertFalse(DatabaseSelection.isNoFilter(db.filter));
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that {@code scope(prefix, inner)} is
+     * detected even when it is nested inside a {@code group(...)} clause that
+     * is conjoined with another condition &mdash; the engine still needs to
+     * evaluate the scoped sub-tree, so the {@link LoadRecordSelection} must be
+     * promoted to a {@link UniqueSelection}.
+     * <p>
+     * <strong>Start state:</strong> No prior state needed.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Build a {@link LoadRecordSelection} via {@code id(...)}.</li>
+     * <li>Build a {@link Criteria} of the form
+     * {@code (scope(prefix, inner)) AND key = value}.</li>
+     * <li>Call {@link Selection#withInjectedCriteria}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The result is a {@link UniqueSelection},
+     * because the scoped sub-tree was discovered during the recursive
+     * inspection of the injected {@link Criteria}.
+     */
+    @Test
+    public void testLoadRecordSelectionDetectsNestedScopedCriteria() {
+        Criteria nested = Criteria.where()
+                .group(Criteria.where().scope("parent.children",
+                        Criteria.where().key("user.userId")
+                                .operator(Operator.EQUALS).value(7L)))
+                .and().key("active").operator(Operator.EQUALS).value(true)
+                .build();
+        Selection<TestRecord> sel = Selection.of(TestRecord.class).id(42L)
+                .build();
+        Selection<TestRecord> result = Selection.withInjectedCriteria(sel,
+                nested);
+        Assert.assertFalse(result instanceof LoadRecordSelection);
+        Assert.assertTrue(result instanceof UniqueSelection);
+    }
+
+    /**
      * A simple {@link Record} subclass for testing.
      */
     static class TestRecord extends Record {} // empty — used only for type

--- a/src/test/java/com/cinchapi/runway/SelectionWithInjectedCriteriaTest.java
+++ b/src/test/java/com/cinchapi/runway/SelectionWithInjectedCriteriaTest.java
@@ -429,18 +429,22 @@ public class SelectionWithInjectedCriteriaTest {
      * <strong>Goal:</strong> Verify that the {@link UniqueSelection} produced
      * by promoting a {@link LoadRecordSelection} on the scope-bearing path
      * carries a {@link Criteria} that
-     * {@link Record#isDatabaseResolvableCondition} accepts. Without this
-     * guarantee, {@code $selectCriteria} falls back to
-     * {@code filter()}/{@code filterAny()}, which calls
-     * {@link Record#matches(Criteria)} on the scope-bearing criteria and throws
-     * {@link UnsupportedOperationException} at runtime.
+     * {@link Record#isDatabaseResolvableCondition} accepts, including when the
+     * scoped inner condition uses a scalar key that is not intrinsic to the
+     * outer class. CCL analysis flattens the inner key into the criteria's key
+     * set, so without scope-aware handling
+     * {@link Record#isDatabaseResolvableCondition} would reject the inner
+     * scalar key and route execution to local {@link Record#matches(Criteria)},
+     * reintroducing {@link UnsupportedOperationException}.
      * <p>
      * <strong>Start state:</strong> No prior state needed.
      * <p>
      * <strong>Workflow:</strong>
      * <ul>
      * <li>Build a {@link LoadRecordSelection} via {@code id(42L)}.</li>
-     * <li>Build a scope-bearing {@link Criteria}.</li>
+     * <li>Build a scope-bearing {@link Criteria} whose inner condition mixes a
+     * scalar key ({@code role}) with a navigation key
+     * ({@code user.userId}).</li>
      * <li>Call {@link Selection#withInjectedCriteria}.</li>
      * <li>Test the promoted {@link UniqueSelection}'s criteria against
      * {@link Record#isDatabaseResolvableCondition}.</li>
@@ -451,9 +455,11 @@ public class SelectionWithInjectedCriteriaTest {
      */
     @Test
     public void testLoadRecordSelectionWithScopedCriteriaPromotedCriteriaIsDatabaseResolvable() {
-        Criteria scoped = Criteria
-                .where().scope("parent.children", Criteria.where()
-                        .key("user.userId").operator(Operator.EQUALS).value(7L))
+        Criteria scoped = Criteria.where()
+                .scope("parent.children",
+                        Criteria.where().key("role").operator(Operator.EQUALS)
+                                .value("OWNER").and().key("user.userId")
+                                .operator(Operator.EQUALS).value(7L))
                 .build();
         Selection<TestRecord> sel = Selection.of(TestRecord.class).id(42L)
                 .build();

--- a/src/test/java/com/cinchapi/runway/SelectionWithInjectedCriteriaTest.java
+++ b/src/test/java/com/cinchapi/runway/SelectionWithInjectedCriteriaTest.java
@@ -506,6 +506,13 @@ public class SelectionWithInjectedCriteriaTest {
     /**
      * A simple {@link Record} subclass for testing.
      */
-    static class TestRecord extends Record {}
+    static class TestRecord extends Record {
+
+        /**
+         * A model field.
+         */
+        @SuppressWarnings("unused")
+        String name;
+    }
 
 }

--- a/src/test/java/com/cinchapi/runway/access/ScopeTest.java
+++ b/src/test/java/com/cinchapi/runway/access/ScopeTest.java
@@ -224,29 +224,26 @@ public class ScopeTest {
 
     /**
      * <strong>Goal:</strong> Verify that
-     * {@link Scope#hybrid(Criteria, Predicate)} returns a {@link Selection}
-     * that differs from the input and carries the injected {@link Criteria}
-     * &mdash; i.e., that the criteria is routed through the database-injection
-     * path just like {@link Scope#of(Criteria)}.
+     * {@link Scope#hybrid(Criteria, Predicate)} routes through the same
+     * database-injection path as {@link Scope#of(Criteria)} &mdash; i.e., that
+     * {@code apply} returns a {@link Selection} distinct from the input rather
+     * than the input itself. The downstream behavior of
+     * {@link Selection#withInjectedCriteria} is covered by
+     * {@code SelectionWithInjectedCriteriaTest}, so this test only verifies the
+     * delegation.
      * <p>
      * <strong>Start state:</strong> No prior state needed.
      * <p>
      * <strong>Workflow:</strong>
      * <ul>
-     * <li>Create a non-scoped {@link Criteria} with a uniquely identifiable
-     * value and a {@link Selection}.</li>
+     * <li>Create a non-scoped {@link Criteria} and a {@link Selection}.</li>
      * <li>Call
      * {@link Scope#hybrid(Criteria, Predicate)}.{@code apply(selection)} with
      * an always-true predicate.</li>
-     * <li>Inspect the returned {@link Selection Selection's}
-     * {@link Object#toString() toString()}, which reflects the resolved
-     * criteria.</li>
      * </ul>
      * <p>
-     * <strong>Expected:</strong> The returned {@link Selection} is non-null, is
-     * not the same reference as the input, and its rendered form contains both
-     * the injected criteria's key and its sentinel value, proving the criteria
-     * was injected into the resulting query.
+     * <strong>Expected:</strong> The returned {@link Selection} is non-null and
+     * is not the same reference as the input.
      */
     @Test
     public void testHybridApplyReturnsModifiedSelection() {
@@ -257,9 +254,6 @@ public class ScopeTest {
                 .apply(selection);
         Assert.assertNotNull(result);
         Assert.assertNotSame(selection, result);
-        String description = result.toString();
-        Assert.assertTrue(description.contains("active"));
-        Assert.assertTrue(description.contains("424242"));
     }
 
     /**

--- a/src/test/java/com/cinchapi/runway/access/ScopeTest.java
+++ b/src/test/java/com/cinchapi/runway/access/ScopeTest.java
@@ -225,31 +225,41 @@ public class ScopeTest {
     /**
      * <strong>Goal:</strong> Verify that
      * {@link Scope#hybrid(Criteria, Predicate)} returns a {@link Selection}
-     * that differs from the input, routing the criteria through the
-     * database-injection path just like {@link Scope#of(Criteria)}.
+     * that differs from the input and carries the injected {@link Criteria}
+     * &mdash; i.e., that the criteria is routed through the database-injection
+     * path just like {@link Scope#of(Criteria)}.
      * <p>
      * <strong>Start state:</strong> No prior state needed.
      * <p>
      * <strong>Workflow:</strong>
      * <ul>
-     * <li>Create a non-scoped {@link Criteria} and a {@link Selection}.</li>
+     * <li>Create a non-scoped {@link Criteria} with a uniquely identifiable
+     * value and a {@link Selection}.</li>
      * <li>Call
      * {@link Scope#hybrid(Criteria, Predicate)}.{@code apply(selection)} with
      * an always-true predicate.</li>
+     * <li>Inspect the returned {@link Selection Selection's}
+     * {@link Object#toString() toString()}, which reflects the resolved
+     * criteria.</li>
      * </ul>
      * <p>
-     * <strong>Expected:</strong> A non-null {@link Selection} is returned that
-     * is not the same reference as the input.
+     * <strong>Expected:</strong> The returned {@link Selection} is non-null, is
+     * not the same reference as the input, and its rendered form contains both
+     * the injected criteria's key and its sentinel value, proving the criteria
+     * was injected into the resulting query.
      */
     @Test
     public void testHybridApplyReturnsModifiedSelection() {
         Criteria criteria = Criteria.where().key("active")
-                .operator(Operator.EQUALS).value(true).build();
+                .operator(Operator.EQUALS).value(424242L).build();
         Selection<?> selection = Selection.of(TestRecord.class);
         Selection<?> result = Scope.hybrid(criteria, r -> true)
                 .apply(selection);
         Assert.assertNotNull(result);
         Assert.assertNotSame(selection, result);
+        String description = result.toString();
+        Assert.assertTrue(description.contains("active"));
+        Assert.assertTrue(description.contains("424242"));
     }
 
     /**

--- a/src/test/java/com/cinchapi/runway/access/ScopeTest.java
+++ b/src/test/java/com/cinchapi/runway/access/ScopeTest.java
@@ -307,7 +307,7 @@ public class ScopeTest {
 
     /**
      * <strong>Goal:</strong> Verify that
-     * {@link Scope#hybrid(Audience, Criteria)} (the convenience form) defaults
+     * {@link Scope#hybrid(Criteria, Audience)} (the convenience form) defaults
      * the per-record predicate to {@link AccessControl#$isDiscoverableBy} for a
      * non-anonymous {@link Audience}.
      * <p>
@@ -331,7 +331,7 @@ public class ScopeTest {
         Criteria criteria = Criteria.where().key("active")
                 .operator(Operator.EQUALS).value(true).build();
         TestAudience audience = new TestAudience();
-        Scope scope = Scope.hybrid(audience, criteria);
+        Scope scope = Scope.hybrid(criteria, audience);
         Assert.assertTrue(scope.test(new TestAccessControlRecord(true, false)));
         Assert.assertFalse(
                 scope.test(new TestAccessControlRecord(false, true)));
@@ -339,7 +339,7 @@ public class ScopeTest {
 
     /**
      * <strong>Goal:</strong> Verify that
-     * {@link Scope#hybrid(Audience, Criteria)} defaults the per-record
+     * {@link Scope#hybrid(Criteria, Audience)} defaults the per-record
      * predicate to {@link AccessControl#$isDiscoverableByAnonymous} when the
      * supplied {@link Audience} is {@link Audience#anonymous()}.
      * <p>
@@ -361,7 +361,7 @@ public class ScopeTest {
     public void testHybridDefaultPredicateUsesAnonymousDiscoverability() {
         Criteria criteria = Criteria.where().key("active")
                 .operator(Operator.EQUALS).value(true).build();
-        Scope scope = Scope.hybrid(Audience.anonymous(), criteria);
+        Scope scope = Scope.hybrid(criteria, Audience.anonymous());
         Assert.assertTrue(scope.test(new TestAccessControlRecord(false, true)));
         Assert.assertFalse(
                 scope.test(new TestAccessControlRecord(true, false)));
@@ -369,7 +369,7 @@ public class ScopeTest {
 
     /**
      * <strong>Goal:</strong> Verify that the default predicate built by
-     * {@link Scope#hybrid(Audience, Criteria)} returns {@code true} for records
+     * {@link Scope#hybrid(Criteria, Audience)} returns {@code true} for records
      * that do not implement {@link AccessControl}, matching the permissive
      * treatment such records receive elsewhere in the framework.
      * <p>
@@ -388,7 +388,7 @@ public class ScopeTest {
     public void testHybridDefaultPredicateAllowsNonAccessControlRecord() {
         Criteria criteria = Criteria.where().key("active")
                 .operator(Operator.EQUALS).value(true).build();
-        Scope scope = Scope.hybrid(new TestAudience(), criteria);
+        Scope scope = Scope.hybrid(criteria, new TestAudience());
         Assert.assertTrue(scope.test(new TestRecord()));
     }
 
@@ -436,7 +436,7 @@ public class ScopeTest {
 
     /**
      * A minimal {@link Audience} implementation used to verify the
-     * non-anonymous branch of {@link Scope#hybrid(Audience, Criteria)}'s
+     * non-anonymous branch of {@link Scope#hybrid(Criteria, Audience)}'s
      * default predicate.
      */
     static class TestAudience extends Record implements Audience {}

--- a/src/test/java/com/cinchapi/runway/access/ScopeTest.java
+++ b/src/test/java/com/cinchapi/runway/access/ScopeTest.java
@@ -15,6 +15,11 @@
  */
 package com.cinchapi.runway.access;
 
+import java.util.Set;
+import java.util.function.Predicate;
+
+import javax.annotation.Nonnull;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -218,9 +223,301 @@ public class ScopeTest {
     }
 
     /**
+     * <strong>Goal:</strong> Verify that
+     * {@link Scope#hybrid(Criteria, Predicate)} returns a {@link Selection}
+     * that differs from the input, routing the criteria through the
+     * database-injection path just like {@link Scope#of(Criteria)}.
+     * <p>
+     * <strong>Start state:</strong> No prior state needed.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Create a non-scoped {@link Criteria} and a {@link Selection}.</li>
+     * <li>Call
+     * {@link Scope#hybrid(Criteria, Predicate)}.{@code apply(selection)} with
+     * an always-true predicate.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> A non-null {@link Selection} is returned that
+     * is not the same reference as the input.
+     */
+    @Test
+    public void testHybridApplyReturnsModifiedSelection() {
+        Criteria criteria = Criteria.where().key("active")
+                .operator(Operator.EQUALS).value(true).build();
+        Selection<?> selection = Selection.of(TestRecord.class);
+        Selection<?> result = Scope.hybrid(criteria, r -> true)
+                .apply(selection);
+        Assert.assertNotNull(result);
+        Assert.assertNotSame(selection, result);
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that
+     * {@link Scope#hybrid(Criteria, Predicate)} reports {@code true} from
+     * {@link Scope#isApplicable()}.
+     * <p>
+     * <strong>Start state:</strong> No prior state needed.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Construct a hybrid {@link Scope} with any criteria and
+     * predicate.</li>
+     * <li>Call {@link Scope#isApplicable()}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> {@code true} is returned.
+     */
+    @Test
+    public void testHybridIsApplicable() {
+        Criteria criteria = Criteria.where().key("active")
+                .operator(Operator.EQUALS).value(true).build();
+        Assert.assertTrue(Scope.hybrid(criteria, r -> true).isApplicable());
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that
+     * {@link Scope#hybrid(Criteria, Predicate)}.{@code test(record)} dispatches
+     * to the supplied {@link Predicate} rather than evaluating the
+     * {@link Criteria} locally. This is the whole point of the hybrid form: the
+     * criteria is reserved for the database path and the predicate owns
+     * per-record visibility.
+     * <p>
+     * <strong>Start state:</strong> No prior state needed.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Construct a hybrid {@link Scope} with an always-true predicate and
+     * call {@code test} on a record.</li>
+     * <li>Construct a hybrid {@link Scope} with an always-false predicate and
+     * call {@code test} on the same record.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The first call returns {@code true}; the
+     * second returns {@code false}.
+     */
+    @Test
+    public void testHybridTestUsesExplicitPredicate() {
+        Criteria criteria = Criteria.where().key("active")
+                .operator(Operator.EQUALS).value(true).build();
+        TestRecord record = new TestRecord();
+        Assert.assertTrue(Scope.hybrid(criteria, r -> true).test(record));
+        Assert.assertFalse(Scope.hybrid(criteria, r -> false).test(record));
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that
+     * {@link Scope#hybrid(Audience, Criteria)} (the convenience form) defaults
+     * the per-record predicate to {@link AccessControl#$isDiscoverableBy} for a
+     * non-anonymous {@link Audience}.
+     * <p>
+     * <strong>Start state:</strong> No prior state needed.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Construct a {@link TestAudience}.</li>
+     * <li>Construct two {@link TestAccessControlRecord
+     * TestAccessControlRecords}: one that is discoverable by the audience, one
+     * that is not.</li>
+     * <li>Call {@code Scope.hybrid(audience, criteria).test(record)} on
+     * each.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The discoverable record passes; the
+     * undiscoverable record does not.
+     */
+    @Test
+    public void testHybridDefaultPredicateUsesIsDiscoverableBy() {
+        Criteria criteria = Criteria.where().key("active")
+                .operator(Operator.EQUALS).value(true).build();
+        TestAudience audience = new TestAudience();
+        Scope scope = Scope.hybrid(audience, criteria);
+        Assert.assertTrue(scope.test(new TestAccessControlRecord(true, false)));
+        Assert.assertFalse(
+                scope.test(new TestAccessControlRecord(false, true)));
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that
+     * {@link Scope#hybrid(Audience, Criteria)} defaults the per-record
+     * predicate to {@link AccessControl#$isDiscoverableByAnonymous} when the
+     * supplied {@link Audience} is {@link Audience#anonymous()}.
+     * <p>
+     * <strong>Start state:</strong> No prior state needed.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Construct two {@link TestAccessControlRecord
+     * TestAccessControlRecords}: one anonymous-discoverable, one not.</li>
+     * <li>Call
+     * {@code Scope.hybrid(Audience.anonymous(), criteria).test(record)} on
+     * each.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The anonymous-discoverable record passes; the
+     * other does not.
+     */
+    @Test
+    public void testHybridDefaultPredicateUsesAnonymousDiscoverability() {
+        Criteria criteria = Criteria.where().key("active")
+                .operator(Operator.EQUALS).value(true).build();
+        Scope scope = Scope.hybrid(Audience.anonymous(), criteria);
+        Assert.assertTrue(scope.test(new TestAccessControlRecord(false, true)));
+        Assert.assertFalse(
+                scope.test(new TestAccessControlRecord(true, false)));
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that the default predicate built by
+     * {@link Scope#hybrid(Audience, Criteria)} returns {@code true} for records
+     * that do not implement {@link AccessControl}, matching the permissive
+     * treatment such records receive elsewhere in the framework.
+     * <p>
+     * <strong>Start state:</strong> No prior state needed.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Construct a hybrid {@link Scope} with a {@link TestAudience}.</li>
+     * <li>Call {@code test} on a {@link TestRecord} (not
+     * {@link AccessControl}).</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> {@code true} is returned.
+     */
+    @Test
+    public void testHybridDefaultPredicateAllowsNonAccessControlRecord() {
+        Criteria criteria = Criteria.where().key("active")
+                .operator(Operator.EQUALS).value(true).build();
+        Scope scope = Scope.hybrid(new TestAudience(), criteria);
+        Assert.assertTrue(scope.test(new TestRecord()));
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that
+     * {@link Scope#hybrid(Criteria, Predicate)}.{@code apply(selection)}
+     * succeeds when the {@link Criteria} contains a scoped navigation clause.
+     * This is the escape-hatch behavior that motivates the hybrid form:
+     * {@link Scope#of(Criteria)} would also route through
+     * {@link Selection#withInjectedCriteria}, but its per-record {@code test()}
+     * would later throw because the local CCL compiler cannot evaluate scoped
+     * conditions. The hybrid form sidesteps that by holding the predicate
+     * separately.
+     * <p>
+     * <strong>Start state:</strong> No prior state needed.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Build a {@link Criteria} containing
+     * {@code scope(prefix, inner)}.</li>
+     * <li>Call {@link Scope#hybrid(Criteria, Predicate)}.{@code apply} with an
+     * always-true predicate and a {@link Selection}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> A non-null {@link Selection} distinct from the
+     * input is returned.
+     */
+    @Test
+    public void testHybridAcceptsScopeBearingCriteria() {
+        Criteria scoped = Criteria
+                .where().scope("parent.children", Criteria.where()
+                        .key("user.userId").operator(Operator.EQUALS).value(7L))
+                .build();
+        Selection<?> selection = Selection.of(TestRecord.class);
+        Selection<?> result = Scope.hybrid(scoped, r -> true).apply(selection);
+        Assert.assertNotNull(result);
+        Assert.assertNotSame(selection, result);
+    }
+
+    /**
      * A minimal {@link Record} used as the type parameter for {@link Selection}
      * instances in these tests.
      */
     static class TestRecord extends Record {}
+
+    /**
+     * A minimal {@link Audience} implementation used to verify the
+     * non-anonymous branch of {@link Scope#hybrid(Audience, Criteria)}'s
+     * default predicate.
+     */
+    static class TestAudience extends Record implements Audience {}
+
+    /**
+     * A minimal {@link AccessControl} {@link Record} whose discoverability for
+     * both authenticated and anonymous {@link Audience audiences} is set at
+     * construction time. All other access methods deny.
+     */
+    static class TestAccessControlRecord extends Record implements
+            AccessControl {
+
+        /**
+         * Whether this record is discoverable by a non-anonymous
+         * {@link Audience}.
+         */
+        private final boolean discoverable;
+
+        /**
+         * Whether this record is discoverable by an anonymous {@link Audience}.
+         */
+        private final boolean discoverableAnonymous;
+
+        /**
+         * Construct a new {@link TestAccessControlRecord}.
+         *
+         * @param discoverable value returned by
+         *            {@link #$isDiscoverableBy(Audience)}
+         * @param discoverableAnonymous value returned by
+         *            {@link #$isDiscoverableByAnonymous()}
+         */
+        TestAccessControlRecord(boolean discoverable,
+                boolean discoverableAnonymous) {
+            this.discoverable = discoverable;
+            this.discoverableAnonymous = discoverableAnonymous;
+        }
+
+        @Override
+        public boolean $isCreatableBy(@Nonnull Audience audience) {
+            return false;
+        }
+
+        @Override
+        public boolean $isCreatableByAnonymous() {
+            return false;
+        }
+
+        @Override
+        public boolean $isDeletableBy(@Nonnull Audience audience) {
+            return false;
+        }
+
+        @Override
+        public boolean $isDiscoverableBy(@Nonnull Audience audience) {
+            return discoverable;
+        }
+
+        @Override
+        public boolean $isDiscoverableByAnonymous() {
+            return discoverableAnonymous;
+        }
+
+        @Override
+        public Set<String> $readableBy(@Nonnull Audience audience) {
+            return NO_KEYS;
+        }
+
+        @Override
+        public Set<String> $readableByAnonymous() {
+            return NO_KEYS;
+        }
+
+        @Override
+        public Set<String> $writableBy(@Nonnull Audience audience) {
+            return NO_KEYS;
+        }
+
+        @Override
+        public Set<String> $writableByAnonymous() {
+            return NO_KEYS;
+        }
+    }
 
 }

--- a/src/test/java/com/cinchapi/runway/access/ScopeTest.java
+++ b/src/test/java/com/cinchapi/runway/access/ScopeTest.java
@@ -329,7 +329,7 @@ public class ScopeTest {
      * <li>Construct two {@link TestAccessControlRecord
      * TestAccessControlRecords}: one that is discoverable by the audience, one
      * that is not.</li>
-     * <li>Call {@code Scope.hybrid(audience, criteria).test(record)} on
+     * <li>Call {@code Scope.hybrid(criteria, audience).test(record)} on
      * each.</li>
      * </ul>
      * <p>
@@ -360,7 +360,7 @@ public class ScopeTest {
      * <li>Construct two {@link TestAccessControlRecord
      * TestAccessControlRecords}: one anonymous-discoverable, one not.</li>
      * <li>Call
-     * {@code Scope.hybrid(Audience.anonymous(), criteria).test(record)} on
+     * {@code Scope.hybrid(criteria, Audience.anonymous()).test(record)} on
      * each.</li>
      * </ul>
      * <p>


### PR DESCRIPTION
## Summary
- Loading an access-controlled `Record` through an `Audience` (e.g., `Audience#load(Class, long)`) threw `UnsupportedOperationException` when the class's registered visibility `Scope` used a scoped navigation criteria (`Criteria.where().scope(prefix, inner)`). The local CCL compiler cannot evaluate same-destination scoped conditions, but the `LoadRecordSelection` branch of `Selection.withInjectedCriteria` was routing the visibility predicate through `Record#matches(Criteria)`.
- `Selection.withInjectedCriteria` now detects scope-bearing injected criteria and promotes the `LoadRecordSelection` to a `UniqueSelection` anchored at `$id$ = id AND injected`, so the engine evaluates the scoped predicate. Non-scope criteria continues to use the existing local-filter path.
- `DatabaseSelection.isScopeBearing(Criteria)` walks the criteria's symbol tree recursively to detect `ScopeSymbol` at any depth, so scoped sub-trees nested inside `group(...)` are caught too.

Resolves [GH-125](https://github.com/cinchapi/runway/issues/125).

## Test plan
- [x] `./gradlew compileJava` passes
- [x] `./gradlew compileTestJava` passes
- [x] `./gradlew spotlessApply` reports no remaining changes
- [ ] New `SelectionWithInjectedCriteriaTest` cases pass (run against a live Concourse server):
  - `testLoadRecordSelectionWithScopedCriteriaBecomesUniqueSelection`
  - `testLoadRecordSelectionWithSimpleCriteriaKeepsLocalFilter`
  - `testLoadRecordSelectionDetectsNestedScopedCriteria`
- [ ] The end-to-end regression test in `cinchapi/cinchapi-server` branch `feature/upgrade-to-concourse-1.0.1` (`SubscriptionTest.testVisibilityScopeLimitsSubscriptionToBillingRoleHolders`) passes once this fix is in place.