### PR TITLE
GH-128: SerializationOptions.includeComputedValuesByDefault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+#### Version 2.1.0 (TBD)
+* **Added `SerializationOptions.includeComputedValuesByDefault`** (default `true`). When set to `false`, `@Computed` properties are omitted from `Record#map()` and `Record#json()` output unless explicitly named in a positive include list, and their suppliers are never invoked. This is useful for serialization paths driven by negative-key access rules (e.g., a `$readableBy` rule like `{"-field1", "-field2"}` that means "everything except these"), where the implicit "all readable" expansion would otherwise materialize every computed property regardless of cost. ([GH-128](https://github.com/cinchapi/runway/issues/128))
+    * `Audience#frame` has a new overload that accepts `SerializationOptions`, allowing access-controlled framing to opt out of computed-property evaluation (or otherwise customize materialization). The existing `frame(Collection<String>, Record)` and `frame(Record)` overloads delegate with `SerializationOptions.defaults()`, preserving prior behavior.
+
 #### Version 2.0.0 (May 20, 2026)
 
 ##### Command API

--- a/src/main/java/com/cinchapi/runway/Record.java
+++ b/src/main/java/com/cinchapi/runway/Record.java
@@ -1478,6 +1478,9 @@ public abstract class Record implements Comparable<Record> {
         Stream<Entry<String, Object>> pool;
         if(include.isEmpty()) {
             pool = data().entrySet().stream();
+            if(!options.includeComputedValuesByDefault()) {
+                pool = pool.filter(e -> !(e instanceof ComputedEntry));
+            }
         }
         else {
             // NOTE: later on the #filter will attempt to remove keys that

--- a/src/main/java/com/cinchapi/runway/SerializationOptions.java
+++ b/src/main/java/com/cinchapi/runway/SerializationOptions.java
@@ -53,15 +53,23 @@ public final class SerializationOptions {
     private final boolean serializeNullValues;
 
     /**
+     * A boolean that indicates if computed values should be included by default
+     */
+    private final boolean includeComputedValuesByDefault;
+
+    /**
      * Constructor
      *
      * @param flattenSingleElementCollections
      * @param serializeNullValues
+     * @param includeComputedValuesByDefault
      */
     private SerializationOptions(boolean flattenSingleElementCollections,
-            boolean serializeNullValues) {
+            boolean serializeNullValues,
+            boolean includeComputedValuesByDefault) {
         this.flattenSingleElementCollections = flattenSingleElementCollections;
         this.serializeNullValues = serializeNullValues;
+        this.includeComputedValuesByDefault = includeComputedValuesByDefault;
     }
 
     /**
@@ -84,6 +92,15 @@ public final class SerializationOptions {
     }
 
     /**
+     * Returns if computed values should be included by default
+     *
+     * @return boolean
+     */
+    public boolean includeComputedValuesByDefault() {
+        return includeComputedValuesByDefault;
+    }
+
+    /**
      * Returned from {@link #builder()}.
      *
      * @author Jeff Nelson
@@ -92,6 +109,7 @@ public final class SerializationOptions {
 
         private boolean flattenSingleElementCollections = false;
         private boolean serializeNullValues = false;
+        private boolean includeComputedValuesByDefault = true;
 
         /**
          * Construct a new instance.
@@ -101,12 +119,12 @@ public final class SerializationOptions {
         /**
          * Build the {@link SerializationOptions} with the parameters that were
          * provided to this builder.
-         * 
+         *
          * @return the {@link SerializationOptions}.
          */
         public SerializationOptions build() {
             return new SerializationOptions(flattenSingleElementCollections,
-                    serializeNullValues);
+                    serializeNullValues, includeComputedValuesByDefault);
         }
 
         /**
@@ -125,12 +143,25 @@ public final class SerializationOptions {
         /**
          * Configure the option to include null values within the data that is
          * returned (instead of dropping the key/value pair).
-         * 
+         *
          * @param serializeNullValues
          * @return this
          */
         public Builder serializeNullValues(boolean serializeNullValues) {
             this.serializeNullValues = serializeNullValues;
+            return this;
+        }
+
+        /**
+         * Configure the option to include computed values by default when
+         * serializing data.
+         *
+         * @param includeComputedValuesByDefault
+         * @return this
+         */
+        public Builder includeComputedValuesByDefault(
+                boolean includeComputedValuesByDefault) {
+            this.includeComputedValuesByDefault = includeComputedValuesByDefault;
             return this;
         }
     }

--- a/src/main/java/com/cinchapi/runway/access/Audience.java
+++ b/src/main/java/com/cinchapi/runway/access/Audience.java
@@ -260,7 +260,7 @@ public interface Audience extends DatabaseInterface {
      * @param keys the fields to read from
      * @param subject the {@link Record} to read from
      * @param <T> the type of the {@link Record}
-     * @return a map of visible data or {@code null} if the {@code record} is
+     * @return a map of visible data or {@code null} if the {@code subject} is
      *         not discoverable at all by this {@link Audience}
      * @see #frame(SerializationOptions, Collection, Record)
      */
@@ -307,7 +307,7 @@ public interface Audience extends DatabaseInterface {
      * @param keys the fields to read from
      * @param subject the {@link Record} to read from
      * @param <T> the type of the {@link Record}
-     * @return a map of visible data or {@code null} if the {@code record} is
+     * @return a map of visible data or {@code null} if the {@code subject} is
      *         not discoverable at all by this {@link Audience}
      */
     @SuppressWarnings("unchecked")

--- a/src/main/java/com/cinchapi/runway/access/Audience.java
+++ b/src/main/java/com/cinchapi/runway/access/Audience.java
@@ -41,6 +41,7 @@ import com.cinchapi.runway.DatabaseInterface;
 import com.cinchapi.runway.Record;
 import com.cinchapi.runway.Selection;
 import com.cinchapi.runway.Selections;
+import com.cinchapi.runway.SerializationOptions;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multiset;
@@ -109,6 +110,31 @@ public interface Audience extends DatabaseInterface {
 
     /**
      * Return a {@link Predicate} that tests whether a {@link Record} is visible
+     * to this {@link Audience}, using the registered {@link Scope} if one
+     * exists and is {@link Scope#isApplicable() applicable}, or falling back to
+     * {@link #$checkIfVisible()} otherwise.
+     * <p>
+     * This is a framework-private method and should not be called directly.
+     * </p>
+     *
+     * @return a {@link Predicate} to filter for visible records
+     */
+    public default <T extends Record> Predicate<T> $checkIfInScopeOrVisible() {
+        // TODO: make private in Java 9+
+        return record -> {
+            if(record instanceof AccessControl) {
+                Scope scope = AccessControl
+                        .resolveVisibilityScope(record.getClass(), this);
+                if(scope != null && scope.isApplicable()) {
+                    return scope.test(record);
+                }
+            }
+            return $checkIfVisible().test(record);
+        };
+    }
+
+    /**
+     * Return a {@link Predicate} that tests whether a {@link Record} is visible
      * to this {@link Audience}.
      * <p>
      * This is a framework-private method and should not be called directly.
@@ -146,31 +172,6 @@ public interface Audience extends DatabaseInterface {
             else {
                 return true;
             }
-        };
-    }
-
-    /**
-     * Return a {@link Predicate} that tests whether a {@link Record} is visible
-     * to this {@link Audience}, using the registered {@link Scope} if one
-     * exists and is {@link Scope#isApplicable() applicable}, or falling back to
-     * {@link #$checkIfVisible()} otherwise.
-     * <p>
-     * This is a framework-private method and should not be called directly.
-     * </p>
-     *
-     * @return a {@link Predicate} to filter for visible records
-     */
-    public default <T extends Record> Predicate<T> $checkIfInScopeOrVisible() {
-        // TODO: make private in Java 9+
-        return record -> {
-            if(record instanceof AccessControl) {
-                Scope scope = AccessControl
-                        .resolveVisibilityScope(record.getClass(), this);
-                if(scope != null && scope.isApplicable()) {
-                    return scope.test(record);
-                }
-            }
-            return $checkIfVisible().test(record);
         };
     }
 
@@ -253,6 +254,23 @@ public interface Audience extends DatabaseInterface {
 
     /**
      * Read a "frame" of data from the {@code record} containing only the
+     * information that is visible to this {@link Audience}, using default
+     * {@link SerializationOptions}.
+     *
+     * @param keys the fields to read from
+     * @param subject the {@link Record} to read from
+     * @param <T> the type of the {@link Record}
+     * @return a map of visible data or {@code null} if the {@code record} is
+     *         not discoverable at all by this {@link Audience}
+     * @see #frame(SerializationOptions, Collection, Record)
+     */
+    public default <T extends Record> Map<String, Object> frame(
+            Collection<String> keys, T subject) {
+        return frame(SerializationOptions.defaults(), keys, subject);
+    }
+
+    /**
+     * Read a "frame" of data from the {@code record} containing only the
      * information that is visible to this {@link Audience}.
      * <p>
      * Unlike {@link #read(Collection, Record)}, this method does not throw a
@@ -283,8 +301,11 @@ public interface Audience extends DatabaseInterface {
      * attempted</li>
      * </ul>
      *
+     * @param options the {@link SerializationOptions} to apply when
+     *            materializing data from the {@code subject} and any linked
+     *            {@link Record Records} encountered during recursive framing
      * @param keys the fields to read from
-     * @param record the {@link Record} to read from
+     * @param subject the {@link Record} to read from
      * @param <T> the type of the {@link Record}
      * @return a map of visible data or {@code null} if the {@code record} is
      *         not discoverable at all by this {@link Audience}
@@ -292,7 +313,7 @@ public interface Audience extends DatabaseInterface {
     @SuppressWarnings("unchecked")
     @Nullable
     public default <T extends Record> Map<String, Object> frame(
-            Collection<String> keys, T subject) {
+            SerializationOptions options, Collection<String> keys, T subject) {
         Preconditions.checkNotNull(keys, "keys cannot be null");
         Map<String, Object> data;
         if(!$checkIfInScopeOrVisible().test(subject)) {
@@ -344,17 +365,17 @@ public interface Audience extends DatabaseInterface {
                 data = new HashMap<>();
             }
             else if(requested.equals(ALL_KEYS) && readable.equals(ALL_KEYS)) {
-                data = subject.map();
+                data = subject.map(options);
             }
             else {
                 if(requested.equals(ALL_KEYS) && !readable.equals(ALL_KEYS)) {
                     String[] visible = readable.toArray(Array.containing());
-                    data = subject.map(visible);
+                    data = subject.map(options, visible);
                 }
                 else if(!requested.equals(ALL_KEYS)
                         && readable.equals(ALL_KEYS)) {
                     String[] visible = requested.toArray(Array.containing());
-                    data = subject.map(visible);
+                    data = subject.map(options, visible);
                 }
                 else {
                     Set<String> allowed = new HashSet<>();
@@ -381,7 +402,7 @@ public interface Audience extends DatabaseInterface {
                         data = new HashMap<>();
                     }
                     else {
-                        data = subject.map(visible);
+                        data = subject.map(options, visible);
                     }
                 }
             }
@@ -413,14 +434,14 @@ public interface Audience extends DatabaseInterface {
                     else if(value instanceof AccessControl) {
                         Record record = (Record) value;
                         seen.add(record);
-                        value = frame(ImmutableSet.copyOf(remaining),
+                        value = frame(options, ImmutableSet.copyOf(remaining),
                                 (T) record);
                         seen.remove(record);
                     }
                     else if(value instanceof Record) {
                         Record record = (Record) value;
                         seen.add(record);
-                        value = record.map(remaining);
+                        value = record.map(options, remaining);
                         seen.remove(record);
                     }
                     else if(Sequences.isSequence(value)) {
@@ -433,14 +454,15 @@ public interface Audience extends DatabaseInterface {
                                 if(item instanceof AccessControl) {
                                     Record record = (Record) item;
                                     seen.add(record);
-                                    item = frame(ImmutableSet.copyOf(remaining),
+                                    item = frame(options,
+                                            ImmutableSet.copyOf(remaining),
                                             (T) record);
                                     seen.remove(record);
                                 }
                                 else if(item instanceof Record) {
                                     Record record = (Record) item;
                                     seen.add(record);
-                                    item = record.map(remaining);
+                                    item = record.map(options, remaining);
                                     seen.remove(record);
                                 }
                             }
@@ -470,7 +492,7 @@ public interface Audience extends DatabaseInterface {
             }
         }
         else {
-            data = subject.map(keys.toArray(Array.containing()));
+            data = subject.map(options, keys.toArray(Array.containing()));
         }
         // By convention, the subject's id should always be included when
         // framing.
@@ -485,18 +507,18 @@ public interface Audience extends DatabaseInterface {
      * information that is visible to this {@link Audience}.
      * <p>
      * This is a convenience method that is equivalent to calling
-     * {@link #frame(Collection, Record)} with all of the keys in the
-     * {@code record}.
+     * {@link #frame(SerializationOptions, Collection, Record)} with all of the
+     * keys in the {@code record} and default {@link SerializationOptions}.
      * </p>
      *
      * @param record the {@link Record} to read from
      * @param <T> the type of the {@link Record}
      * @return a map of visible data or {@code null} if the {@code record} is
      *         not discoverable at all by this {@link Audience}
-     * @see #frame(Collection, Record)
+     * @see #frame(SerializationOptions, Collection, Record)
      */
     public default <T extends Record> Map<String, Object> frame(T record) {
-        return frame(ALL_KEYS, record);
+        return frame(SerializationOptions.defaults(), ALL_KEYS, record);
     }
 
     /**
@@ -550,6 +572,23 @@ public interface Audience extends DatabaseInterface {
             throws RestrictedAccessException {
         Map<String, Object> data = frame(ImmutableSet.of(key), record);
         return data.getOrDefault(key, null);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public default Selections select(Selection<?>... selections) {
+        selections = Arrays.stream(selections).map(selection -> {
+            Class<?> clazz = selection.clazz();
+            if(clazz != null && AccessControl.class.isAssignableFrom(clazz)) {
+                Scope scope = AccessControl.resolveVisibilityScope(clazz, this);
+                if(scope != null && scope.isApplicable()) {
+                    return scope.apply(selection);
+                }
+            }
+            return Selection.withInjectedFilter((Selection<Record>) selection,
+                    $checkIfVisible());
+        }).toArray(Selection[]::new);
+        return $db().select(selections);
     }
 
     /**
@@ -614,23 +653,6 @@ public interface Audience extends DatabaseInterface {
             Reflection.set("_author", (Record) this, record);
         }
         record.set(key, value);
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
-    public default Selections select(Selection<?>... selections) {
-        selections = Arrays.stream(selections).map(selection -> {
-            Class<?> clazz = selection.clazz();
-            if(clazz != null && AccessControl.class.isAssignableFrom(clazz)) {
-                Scope scope = AccessControl.resolveVisibilityScope(clazz, this);
-                if(scope != null && scope.isApplicable()) {
-                    return scope.apply(selection);
-                }
-            }
-            return Selection.withInjectedFilter((Selection<Record>) selection,
-                    $checkIfVisible());
-        }).toArray(Selection[]::new);
-        return $db().select(selections);
     }
 
 }

--- a/src/test/java/com/cinchapi/runway/RecordIncludeComputedValuesTest.java
+++ b/src/test/java/com/cinchapi/runway/RecordIncludeComputedValuesTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2013-2026 Cinchapi Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.cinchapi.runway;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Regression tests proving that a {@link Computed} property's supplier is not
+ * invoked during framing when
+ * {@link SerializationOptions#includeComputedValuesByDefault()} is
+ * {@code false} and the caller supplies either no keys or only negative
+ * (exclusion) keys.
+ *
+ * @author Jeff Nelson
+ */
+public class RecordIncludeComputedValuesTest
+        extends RunwayBaseClientServerTest {
+
+    /**
+     * <strong>Goal:</strong> Verify that the {@link Computed} supplier never
+     * fires when {@code map()} is called with
+     * {@code includeComputedValuesByDefault = false} and no keys.
+     * <p>
+     * <strong>Start state:</strong> A freshly constructed {@link LabeledWidget}
+     * whose computed supplier has not yet run.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Build {@link SerializationOptions} with
+     * {@code includeComputedValuesByDefault(false)}.</li>
+     * <li>Invoke {@code widget.map(opts)} with no keys, which exercises the
+     * {@code data().entrySet()} iteration path.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The supplier invocation counter remains at
+     * {@code 0}, proving the computed entry was filtered out structurally
+     * before {@code getValue()} could fire the supplier.
+     */
+    @Test
+    public void testComputedSupplierDoesNotFireWithNoKeysWhenFlagIsFalse() {
+        LabeledWidget widget = new LabeledWidget();
+        widget.name = "alpha";
+
+        SerializationOptions opts = SerializationOptions.builder()
+                .includeComputedValuesByDefault(false).build();
+
+        widget.map(opts);
+
+        Assert.assertEquals(0, widget.labelInvocations.get());
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that the {@link Computed} supplier never
+     * fires when {@code map()} is called with
+     * {@code includeComputedValuesByDefault = false} and only negative
+     * (exclusion) keys &mdash; the canonical scenario described in the
+     * originating issue.
+     * <p>
+     * <strong>Start state:</strong> A freshly constructed {@link LabeledWidget}
+     * whose computed supplier has not yet run.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Build {@link SerializationOptions} with
+     * {@code includeComputedValuesByDefault(false)}.</li>
+     * <li>Invoke {@code widget.map(opts, "-name")}, supplying a negative-only
+     * key set that still routes through the {@code data().entrySet()} iteration
+     * path.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The supplier invocation counter remains at
+     * {@code 0}.
+     */
+    @Test
+    public void testComputedSupplierDoesNotFireWithNegativeKeysWhenFlagIsFalse() {
+        LabeledWidget widget = new LabeledWidget();
+        widget.name = "alpha";
+
+        SerializationOptions opts = SerializationOptions.builder()
+                .includeComputedValuesByDefault(false).build();
+
+        widget.map(opts, "-name");
+
+        Assert.assertEquals(0, widget.labelInvocations.get());
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that the {@link Computed} supplier never
+     * fires when {@code json()} is called with
+     * {@code includeComputedValuesByDefault = false} and no keys, confirming
+     * the JSON pipeline inherits the same structural-filter guarantee as
+     * {@code map()}.
+     * <p>
+     * <strong>Start state:</strong> A freshly constructed {@link LabeledWidget}
+     * whose computed supplier has not yet run.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Build {@link SerializationOptions} with
+     * {@code includeComputedValuesByDefault(false)}.</li>
+     * <li>Invoke {@code widget.json(opts)} with no keys.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The supplier invocation counter remains at
+     * {@code 0}.
+     */
+    @Test
+    public void testComputedSupplierDoesNotFireDuringJsonWhenFlagIsFalse() {
+        LabeledWidget widget = new LabeledWidget();
+        widget.name = "alpha";
+
+        SerializationOptions opts = SerializationOptions.builder()
+                .includeComputedValuesByDefault(false).build();
+
+        widget.json(opts);
+
+        Assert.assertEquals(0, widget.labelInvocations.get());
+    }
+
+    /**
+     * A {@link Record} with a single {@link Computed} property whose supplier
+     * increments a counter on every invocation, enabling assertions about
+     * whether the supplier fired during framing.
+     */
+    class LabeledWidget extends Record {
+
+        public String name;
+
+        /**
+         * Tracks how many times {@link #label()} has been invoked.
+         */
+        final AtomicInteger labelInvocations = new AtomicInteger(0);
+
+        @Computed
+        public String label() {
+            labelInvocations.incrementAndGet();
+            return "label-" + name;
+        }
+    }
+}

--- a/src/test/java/com/cinchapi/runway/RecordIncludeComputedValuesTest.java
+++ b/src/test/java/com/cinchapi/runway/RecordIncludeComputedValuesTest.java
@@ -15,17 +15,20 @@
  */
 package com.cinchapi.runway;
 
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Assert;
 import org.junit.Test;
 
 /**
- * Regression tests proving that a {@link Computed} property's supplier is not
- * invoked during framing when
- * {@link SerializationOptions#includeComputedValuesByDefault()} is
- * {@code false} and the caller supplies either no keys or only negative
- * (exclusion) keys.
+ * Tests covering how
+ * {@link SerializationOptions#includeComputedValuesByDefault()} controls
+ * whether a {@link Computed} property's supplier fires during {@code map()} and
+ * {@code json()}. When the flag is {@code false}, the supplier is suppressed
+ * for no-keys and negative-only key sets; when the flag is {@code false} but
+ * the caller positively names the computed key, the supplier still fires and
+ * the value appears in the result.
  *
  * @author Jeff Nelson
  */
@@ -131,6 +134,42 @@ public class RecordIncludeComputedValuesTest
         widget.json(opts);
 
         Assert.assertEquals(0, widget.labelInvocations.get());
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that a positive include list overrides
+     * {@code includeComputedValuesByDefault = false} &mdash; explicitly naming
+     * a {@link Computed} key still fires the supplier and produces the value,
+     * which is the documented escape hatch for selective materialization.
+     * <p>
+     * <strong>Start state:</strong> A freshly constructed {@link LabeledWidget}
+     * whose computed supplier has not yet run.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Build {@link SerializationOptions} with
+     * {@code includeComputedValuesByDefault(false)}.</li>
+     * <li>Invoke {@code widget.map(opts, "label")}, routing through the
+     * positive-include branch of {@code map()} that resolves each key via
+     * {@code get()}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The result contains the computed value under
+     * {@code "label"} and the supplier invocation counter reflects exactly one
+     * invocation.
+     */
+    @Test
+    public void testPositiveIncludeOverridesFlagFalse() {
+        LabeledWidget widget = new LabeledWidget();
+        widget.name = "alpha";
+
+        SerializationOptions opts = SerializationOptions.builder()
+                .includeComputedValuesByDefault(false).build();
+
+        Map<String, Object> result = widget.map(opts, "label");
+
+        Assert.assertEquals("label-alpha", result.get("label"));
+        Assert.assertEquals(1, widget.labelInvocations.get());
     }
 
     /**

--- a/src/test/java/com/cinchapi/runway/access/AudienceFrameOptionsTest.java
+++ b/src/test/java/com/cinchapi/runway/access/AudienceFrameOptionsTest.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2013-2026 Cinchapi Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.cinchapi.runway.access;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.annotation.Nonnull;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.cinchapi.runway.Computed;
+import com.cinchapi.runway.Record;
+import com.cinchapi.runway.SerializationOptions;
+
+/**
+ * Tests for the options-aware {@link Audience#frame frame} overloads, verifying
+ * that {@link SerializationOptions} thread from the {@link Audience}
+ * {@code frame} pipeline into the underlying {@link Record#map map} calls, and
+ * that the convenience overloads delegate with
+ * {@link SerializationOptions#defaults() default options}.
+ *
+ * @author Jeff Nelson
+ */
+public class AudienceFrameOptionsTest extends AudienceAccessControlBaseTest {
+
+    /**
+     * <strong>Goal:</strong> Verify that
+     * {@link SerializationOptions#includeComputedValuesByDefault()
+     * includeComputedValuesByDefault} = {@code false} suppresses
+     * {@link Computed} properties when framing through an {@link Audience},
+     * proving that {@link SerializationOptions} thread into the underlying
+     * {@link Record#map map} calls.
+     * <p>
+     * <strong>Start state:</strong> A freshly constructed {@link Admin} and a
+     * freshly constructed {@link WidgetWithComputed} whose computed supplier
+     * has not yet run.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Build {@link SerializationOptions} with
+     * {@code includeComputedValuesByDefault(false)}.</li>
+     * <li>Invoke
+     * {@code admin.frame(opts, AccessControl.ALL_KEYS, widget)}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The framed result omits
+     * {@code "computedLabel"} and the supplier invocation counter remains at
+     * {@code 0}.
+     */
+    @Test
+    public void testFrameWithFlagFalseSuppressesComputed() {
+        Admin admin = new Admin();
+        admin.email = "admin@example.com";
+        admin.name = "Admin";
+
+        WidgetWithComputed widget = new WidgetWithComputed();
+        widget.label = "alpha";
+
+        SerializationOptions opts = SerializationOptions.builder()
+                .includeComputedValuesByDefault(false).build();
+
+        Map<String, Object> result = admin.frame(opts, AccessControl.ALL_KEYS,
+                widget);
+
+        Assert.assertNotNull(result);
+        Assert.assertFalse(result.containsKey("computedLabel"));
+        Assert.assertEquals(0, widget.computedInvocations.get());
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that the two-arg convenience overload
+     * {@link Audience#frame(java.util.Collection, Record) frame(keys, subject)}
+     * delegates to the canonical method with default
+     * {@link SerializationOptions}, preserving prior framing behavior in which
+     * {@link Computed} properties are included.
+     * <p>
+     * <strong>Start state:</strong> Same as
+     * {@link #testFrameWithFlagFalseSuppressesComputed()}.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Invoke {@code admin.frame(AccessControl.ALL_KEYS, widget)} with no
+     * {@link SerializationOptions options}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The result contains {@code "computedLabel"}
+     * and the supplier invocation counter reflects exactly one invocation.
+     */
+    @Test
+    public void testTwoArgFrameDelegatesWithDefaults() {
+        Admin admin = new Admin();
+        admin.email = "admin@example.com";
+        admin.name = "Admin";
+
+        WidgetWithComputed widget = new WidgetWithComputed();
+        widget.label = "alpha";
+
+        Map<String, Object> result = admin.frame(AccessControl.ALL_KEYS,
+                widget);
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals("computed-alpha", result.get("computedLabel"));
+        Assert.assertEquals(1, widget.computedInvocations.get());
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that the one-arg convenience overload
+     * {@link Audience#frame(Record) frame(record)} delegates to the canonical
+     * method with default {@link SerializationOptions} and all keys.
+     * <p>
+     * <strong>Start state:</strong> Same as
+     * {@link #testFrameWithFlagFalseSuppressesComputed()}.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Invoke {@code admin.frame(widget)} with no keys and no
+     * {@link SerializationOptions options}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The result contains {@code "computedLabel"}
+     * and the supplier invocation counter reflects exactly one invocation.
+     */
+    @Test
+    public void testOneArgFrameDelegatesWithDefaults() {
+        Admin admin = new Admin();
+        admin.email = "admin@example.com";
+        admin.name = "Admin";
+
+        WidgetWithComputed widget = new WidgetWithComputed();
+        widget.label = "alpha";
+
+        Map<String, Object> result = admin.frame(widget);
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals("computed-alpha", result.get("computedLabel"));
+        Assert.assertEquals(1, widget.computedInvocations.get());
+    }
+
+    /**
+     * An {@link AccessControl} {@link Record} with one regular field and one
+     * {@link Computed} property whose supplier increments a counter. The access
+     * control rules are intentionally permissive so the framing pipeline always
+     * reaches the underlying {@link Record#map map} call, letting tests focus
+     * on {@link SerializationOptions} threading.
+     */
+    protected static class WidgetWithComputed extends Record implements
+            AccessControl {
+
+        public String label;
+
+        /**
+         * Tracks how many times {@link #computedLabel()} has been invoked.
+         */
+        public final AtomicInteger computedInvocations = new AtomicInteger(0);
+
+        @Computed
+        public String computedLabel() {
+            computedInvocations.incrementAndGet();
+            return "computed-" + label;
+        }
+
+        @Override
+        public boolean $isCreatableBy(@Nonnull Audience audience) {
+            return true;
+        }
+
+        @Override
+        public boolean $isCreatableByAnonymous() {
+            return true;
+        }
+
+        @Override
+        public boolean $isDeletableBy(@Nonnull Audience audience) {
+            return true;
+        }
+
+        @Override
+        public boolean $isDiscoverableBy(@Nonnull Audience audience) {
+            return true;
+        }
+
+        @Override
+        public boolean $isDiscoverableByAnonymous() {
+            return true;
+        }
+
+        @Override
+        public Set<String> $readableBy(@Nonnull Audience audience) {
+            return ALL_KEYS;
+        }
+
+        @Override
+        public Set<String> $readableByAnonymous() {
+            return ALL_KEYS;
+        }
+
+        @Override
+        public Set<String> $writableBy(@Nonnull Audience audience) {
+            return ALL_KEYS;
+        }
+
+        @Override
+        public Set<String> $writableByAnonymous() {
+            return ALL_KEYS;
+        }
+
+        @Override
+        public void deleteAs(Audience audience) {
+            audience.delete(this);
+        }
+    }
+}

--- a/src/test/java/com/cinchapi/runway/access/AudienceFrameOptionsTest.java
+++ b/src/test/java/com/cinchapi/runway/access/AudienceFrameOptionsTest.java
@@ -37,6 +37,7 @@ import com.cinchapi.runway.SerializationOptions;
  *
  * @author Jeff Nelson
  */
+@SuppressWarnings("unchecked")
 public class AudienceFrameOptionsTest extends AudienceAccessControlBaseTest {
 
     /**
@@ -153,16 +154,75 @@ public class AudienceFrameOptionsTest extends AudienceAccessControlBaseTest {
     }
 
     /**
-     * An {@link AccessControl} {@link Record} with one regular field and one
-     * {@link Computed} property whose supplier increments a counter. The access
-     * control rules are intentionally permissive so the framing pipeline always
-     * reaches the underlying {@link Record#map map} call, letting tests focus
-     * on {@link SerializationOptions} threading.
+     * <strong>Goal:</strong> Verify that
+     * {@code includeComputedValuesByDefault = false} propagates from the outer
+     * {@code frame} call into the recursive frame of a linked
+     * {@link AccessControl} {@link Record}, proving that
+     * {@link SerializationOptions} thread through every level of the framing
+     * pipeline &mdash; not just the top-level {@link Record#map map} call.
+     * <p>
+     * <strong>Start state:</strong> A freshly constructed {@link Admin} and two
+     * freshly constructed {@link WidgetWithComputed} records, one linked as the
+     * {@code child} of the other; neither computed supplier has yet run.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Build {@link SerializationOptions} with
+     * {@code includeComputedValuesByDefault(false)}.</li>
+     * <li>Invoke {@code admin.frame(opts, AccessControl.ALL_KEYS, parent)},
+     * which causes the framing pipeline to recurse into the linked
+     * {@code child} via
+     * {@link Audience#frame(SerializationOptions, java.util.Collection, Record)}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The outer framed result omits
+     * {@code "computedLabel"} and the nested framed result for the linked
+     * {@code child} also omits {@code "computedLabel"}; both supplier
+     * invocation counters remain at {@code 0}.
+     */
+    @Test
+    public void testFrameWithFlagFalseSuppressesComputedOnLinkedRecord() {
+        Admin admin = new Admin();
+        admin.email = "admin@example.com";
+        admin.name = "Admin";
+
+        WidgetWithComputed child = new WidgetWithComputed();
+        child.label = "child";
+
+        WidgetWithComputed parent = new WidgetWithComputed();
+        parent.label = "parent";
+        parent.child = child;
+
+        SerializationOptions opts = SerializationOptions.builder()
+                .includeComputedValuesByDefault(false).build();
+
+        Map<String, Object> result = admin.frame(opts, AccessControl.ALL_KEYS,
+                parent);
+
+        Assert.assertNotNull(result);
+        Assert.assertFalse(result.containsKey("computedLabel"));
+        Assert.assertEquals(0, parent.computedInvocations.get());
+
+        Map<String, Object> nested = (Map<String, Object>) result.get("child");
+        Assert.assertNotNull(nested);
+        Assert.assertFalse(nested.containsKey("computedLabel"));
+        Assert.assertEquals(0, child.computedInvocations.get());
+    }
+
+    /**
+     * An {@link AccessControl} {@link Record} with one regular field, one
+     * self-referential {@code child} link, and one {@link Computed} property
+     * whose supplier increments a counter. The access control rules are
+     * intentionally permissive so the framing pipeline always reaches the
+     * underlying {@link Record#map map} call, letting tests focus on
+     * {@link SerializationOptions} threading.
      */
     protected static class WidgetWithComputed extends Record implements
             AccessControl {
 
         public String label;
+
+        public WidgetWithComputed child;
 
         /**
          * Tracks how many times {@link #computedLabel()} has been invoked.


### PR DESCRIPTION
## Summary
- Adds `SerializationOptions.includeComputedValuesByDefault` (default `true`). When set to `false`, `@Computed` properties are structurally filtered out of `Record.map()` and `Record.json()` output unless explicitly named in a positive include list, and their suppliers never fire.
- Threads `SerializationOptions` through `Audience.frame`: new canonical overload `frame(SerializationOptions, Collection<String>, T)` carries options into every internal `map()` and recursive `frame()` call. Existing `frame(Collection<String>, T)` and `frame(T)` overloads delegate with `SerializationOptions.defaults()`.

Closes #128.

## Test plan
- [ ] `RecordIncludeComputedValuesTest` — supplier counter stays at `0` when flag is `false` for no-keys `map()`, negative-keys `map()`, and `json()`.
- [ ] `AudienceFrameOptionsTest` — supplier suppressed when framing with flag `false`; two-arg and one-arg `frame` overloads still include computed under defaults.
- [ ] Existing `AudienceAccessControlFrameTest` continues to pass (delegators preserve prior behavior).