### PR TITLE
GH-93: Clear computeOnce cache on refresh()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+#### Version 2.1.0 (TBD)
+* Fixed a bug where `Record#refresh()` left memoized `@Computed` values cached from before the refresh, so subsequent reads returned stale results instead of recomputing against the refreshed state. ([GH-93](https://github.com/cinchapi/runway/issues/93))
+
 #### Version 2.0.0 (May 20, 2026)
 
 ##### Command API

--- a/src/main/java/com/cinchapi/runway/Record.java
+++ b/src/main/java/com/cinchapi/runway/Record.java
@@ -1580,7 +1580,9 @@ public abstract class Record implements Comparable<Record> {
      * After refreshing, this {@link Record} is considered in sync with the
      * database &mdash; {@link #hasStaleDataWithinTransaction(Concourse)
      * hasStaleDataWithinTransaction} will return {@code false} until the next
-     * external modification occurs.
+     * external modification occurs. The {@link #computeOnce(String, Supplier)
+     * computeOnce} cache is also invalidated so that memoized computed values
+     * recompute against the refreshed state on next access.
      * </p>
      *
      * @throws IllegalStateException if this {@link Record} is not pinned to a
@@ -1593,6 +1595,7 @@ public abstract class Record implements Comparable<Record> {
         try {
             ConcurrentMap<Long, Record> existing = new ConcurrentHashMap<>();
             load(concourse, existing);
+            clearComputeOnceCache();
             onLoad();
         }
         finally {

--- a/src/test/java/com/cinchapi/runway/RecordRefreshTest.java
+++ b/src/test/java/com/cinchapi/runway/RecordRefreshTest.java
@@ -15,6 +15,8 @@
  */
 package com.cinchapi.runway;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -177,6 +179,51 @@ public class RecordRefreshTest extends RunwayBaseClientServerTest {
     }
 
     /**
+     * <strong>Goal:</strong> Verify that {@link Record#refresh()} clears the
+     * {@link Record#computeOnce(String, java.util.function.Supplier)
+     * computeOnce} cache so that previously memoized computed values are
+     * recomputed against the refreshed state.
+     * <p>
+     * <strong>Start state:</strong> A {@link CountingUser} that has been saved
+     * and had its computed {@code greeting} memoized once.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Save a {@link CountingUser} with name "alice".</li>
+     * <li>Invoke {@code greeting()} to populate the {@code computeOnce}
+     * cache.</li>
+     * <li>Externally modify the name to "bob" directly in the database.</li>
+     * <li>Call {@link Record#refresh()} on the {@link CountingUser}.</li>
+     * <li>Invoke {@code greeting()} again.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The second {@code greeting()} call returns
+     * "Hello, bob" instead of the cached "Hello, alice", and the supplier is
+     * invoked twice in total, proving the cache was cleared by the refresh.
+     */
+    @Test
+    public void testRefreshClearsComputeOnceCache() {
+        CountingUser user = new CountingUser("alice");
+        Assert.assertTrue(runway.save(user));
+
+        Assert.assertEquals("Hello, alice", user.greeting());
+        Assert.assertEquals(1, user.greetingInvocations.get());
+
+        Concourse concourse = runway.connections.request();
+        try {
+            concourse.set("name", "bob", user.id());
+        }
+        finally {
+            runway.connections.release(concourse);
+        }
+
+        user.refresh();
+
+        Assert.assertEquals("Hello, bob", user.greeting());
+        Assert.assertEquals(2, user.greetingInvocations.get());
+    }
+
+    /**
      * A test user record.
      *
      * @author Jeff Nelson
@@ -195,6 +242,49 @@ public class RecordRefreshTest extends RunwayBaseClientServerTest {
          */
         public TUser(String name) {
             this.name = name;
+        }
+    }
+
+    /**
+     * A test record with a {@link Computed} method that memoizes its result via
+     * {@link Record#computeOnce(String, java.util.function.Supplier)}.
+     *
+     * @author Jeff Nelson
+     */
+    public static class CountingUser extends Record {
+
+        /**
+         * The user's name.
+         */
+        String name;
+
+        /**
+         * Tracks how many times the greeting supplier has been invoked.
+         */
+        final transient AtomicInteger greetingInvocations = new AtomicInteger(
+                0);
+
+        /**
+         * Construct a new instance.
+         *
+         * @param name the user's name
+         */
+        public CountingUser(String name) {
+            this.name = name;
+        }
+
+        /**
+         * Return a greeting derived from {@link #name}, memoized via
+         * {@link Record#computeOnce(String, java.util.function.Supplier)}.
+         *
+         * @return the greeting
+         */
+        @Computed
+        public String greeting() {
+            return computeOnce("greeting", () -> {
+                greetingInvocations.incrementAndGet();
+                return "Hello, " + name;
+            });
         }
     }
 


### PR DESCRIPTION
## Summary
- `Record#refresh()` now calls `clearComputeOnceCache()` between the database reload and `onLoad()` hook, so memoized `@Computed` values recompute against the refreshed state instead of returning stale cached results.
- Updated `refresh()` Javadoc to document the cache invalidation as part of the contract.
- Added `testRefreshClearsComputeOnceCache` to `RecordRefreshTest`, which seeds the cache via a `@Computed` method, mutates the underlying field through a side-channel write, calls `refresh()`, and asserts the supplier re-fires with the new value.

Closes [GH-93](https://github.com/cinchapi/runway/issues/93).

## Test plan
- [ ] `./gradlew test --tests com.cinchapi.runway.RecordRefreshTest`
- [ ] `./gradlew test --tests com.cinchapi.runway.RecordComputeOnceTest` (regression check on the surrounding `computeOnce` behavior)