### PR TITLE
GH-133: Additive `+` key prefix for map/json/frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
         * Positively naming the `@Computed` key in the keys list (e.g., `record.map("propertyName")`) always fires its supplier regardless of the flag.
     * `Audience#frame` has a new overload, `frame(SerializationOptions, Collection<String>, Record)`, that threads options through every level of the framing pipeline, including recursive frames of linked `AccessControl` records. The existing `frame(Collection<String>, Record)` and `frame(Record)` overloads delegate with `SerializationOptions.defaults()` &mdash; which under the new default now exclude `@Computed` properties.
 * Fixed a bug where `Record#refresh()` left memoized `@Computed` values cached from before the refresh, so subsequent reads returned stale results instead of recomputing against the refreshed state. ([GH-93](https://github.com/cinchapi/runway/issues/93))
+* **Added an additive `+` key prefix to `Record#map`, `Record#json`, and `Audience#frame`** for layering a single key onto the default payload &mdash; the escape hatch for naming one `@Computed` property without enumerating every other key (e.g., `record.map("+computedProperty")` returns the defaults plus the computed value). The moment any bare positive key appears in the call, defaults are dropped and only the listed keys (bare or `+`-prefixed) appear in the result; `-` continues to exclude. Legacy call shapes are unchanged. ([GH-133](https://github.com/cinchapi/runway/issues/133))
+* Fixed a bug where `Audience#frame` silently dropped a `-`-prefixed key against any restricted (non-`ALL_KEYS`) readable set, collapsing the call to an empty map instead of returning the readable defaults minus the excluded key. ([GH-133](https://github.com/cinchapi/runway/issues/133))
 
 #### Version 2.0.0 (May 20, 2026)
 

--- a/src/main/java/com/cinchapi/runway/Record.java
+++ b/src/main/java/com/cinchapi/runway/Record.java
@@ -1382,13 +1382,19 @@ public abstract class Record implements Comparable<Record> {
      * Return a JSON string containing this {@link Record}'s readable and
      * temporary data from the specified {@code keys}.
      * <p>
-     * This method also supports <strong>negative filtering</strong>. You can
-     * prefix any of the {@code keys} with a minus sign (e.g. {@code -}) to
-     * indicate that the key should be excluded from the data that is returned.
+     * This method also supports <strong>negative filtering</strong>. Prefix any
+     * key with {@code -} to exclude it from the result.
+     * </p>
+     * <p>
+     * It also supports <strong>additive selection</strong>. Prefix any key with
+     * {@code +} to include it on top of the defaults. The moment any bare
+     * positive key appears in {@code keys}, the defaults are dropped and only
+     * the listed keys (bare or {@code +}-prefixed) appear in the result.
      * </p>
      *
-     * @param options
-     * @param keys
+     * @param options the {@link SerializationOptions} to apply
+     * @param keys the keys to include (use {@code +} to add to defaults or
+     *            {@code -} to exclude)
      * @return json string
      */
     public String json(SerializationOptions options, String... keys) {
@@ -1399,12 +1405,18 @@ public abstract class Record implements Comparable<Record> {
      * Return a JSON string containing this {@link Record}'s readable and
      * temporary data from the specified {@code keys}.
      * <p>
-     * This method also supports <strong>negative filtering</strong>. You can
-     * prefix any of the {@code keys} with a minus sign (e.g. {@code -}) to
-     * indicate that the key should be excluded from the data that is returned.
+     * This method also supports <strong>negative filtering</strong>. Prefix any
+     * key with {@code -} to exclude it from the result.
+     * </p>
+     * <p>
+     * It also supports <strong>additive selection</strong>. Prefix any key with
+     * {@code +} to include it on top of the defaults. The moment any bare
+     * positive key appears in {@code keys}, the defaults are dropped and only
+     * the listed keys (bare or {@code +}-prefixed) appear in the result.
      * </p>
      *
-     * @param keys
+     * @param keys the keys to include (use {@code +} to add to defaults or
+     *            {@code -} to exclude)
      * @return json string
      */
     public String json(String... keys) {
@@ -1447,22 +1459,32 @@ public abstract class Record implements Comparable<Record> {
      * This method also supports <strong>negative filtering</strong>. Prefix any
      * key with {@code -} to exclude it from the result.
      * </p>
+     * <p>
+     * It also supports <strong>additive selection</strong>. Prefix any key with
+     * {@code +} to include it on top of the defaults. The moment any bare
+     * positive key appears in {@code keys}, the defaults are dropped and only
+     * the listed keys (bare or {@code +}-prefixed) appear in the result.
+     * </p>
      *
      * @param options the {@link SerializationOptions} to apply
-     * @param keys the keys to include (or exclude with {@code -} prefix)
+     * @param keys the keys to include (use {@code +} to add to defaults or
+     *            {@code -} to exclude)
      * @return the data in this {@link Record}
      */
     public Map<String, Object> map(SerializationOptions options,
             String... keys) {
-        List<String> include = Lists.newArrayList();
+        List<String> bare = Lists.newArrayList();
+        List<String> additive = Lists.newArrayList();
         List<String> exclude = Lists.newArrayList();
         for (String key : keys) {
             if(key.startsWith("-")) {
-                key = key.substring(1);
-                exclude.add(key);
+                exclude.add(key.substring(1));
+            }
+            else if(key.startsWith("+")) {
+                additive.add(key.substring(1));
             }
             else {
-                include.add(key);
+                bare.add(key);
             }
         }
         Predicate<Entry<String, Object>> filter = entry -> !exclude
@@ -1486,50 +1508,39 @@ public abstract class Record implements Comparable<Record> {
                 map.put(entry.getKey(), value);
             }
         };
+        // Pre-filter the positive lists against #exclude so the resolver
+        // never fires a @Computed supplier (or navigates a link) for a
+        // key the caller has also excluded.
+        bare.removeAll(exclude);
+        additive.removeAll(exclude);
         Stream<Entry<String, Object>> pool;
-        if(include.isEmpty()) {
+        if(!bare.isEmpty()) {
+            List<String> whitelist = Lists.newArrayList(bare);
+            whitelist.addAll(additive);
+            pool = whitelist.stream().map(key -> resolveEntry(key, options));
+        }
+        else if(!additive.isEmpty()) {
+            // Skip a baseline entry only when an additive names its bare
+            // root; navigation additives like "+a.b" must let the baseline
+            // remain so the slice upserts into the nested map rather than
+            // replacing the rest of the root's contents.
+            Set<String> bareAdditiveRoots = additive.stream()
+                    .filter(k -> !k.contains(".")).collect(Collectors.toSet());
+            Stream<Entry<String, Object>> baseline = data().entrySet().stream();
+            if(!options.includeComputedValuesByDefault()) {
+                baseline = baseline.filter(e -> !(e instanceof ComputedEntry));
+            }
+            baseline = baseline
+                    .filter(e -> !bareAdditiveRoots.contains(e.getKey()));
+            Stream<Entry<String, Object>> added = additive.stream()
+                    .map(key -> resolveEntry(key, options));
+            pool = Stream.concat(baseline, added);
+        }
+        else {
             pool = data().entrySet().stream();
             if(!options.includeComputedValuesByDefault()) {
                 pool = pool.filter(e -> !(e instanceof ComputedEntry));
             }
-        }
-        else {
-            // NOTE: later on the #filter will attempt to remove keys that
-            // are explicitly excluded, which will have no affect here since
-            // #include and #exclude will never both have values at the same
-            // time.
-            pool = include.stream().map(key -> {
-                Object value;
-                String[] stops = key.split("\\.");
-                if(stops.length > 1) {
-                    // For mapping navigation keys, we must manually perform
-                    // the navigation and collect a series of nested
-                    // maps/sequences so that merging multiple navigation keys
-                    // can be done sensibly.
-                    key = stops[0];
-                    String path = StringUtils.join(stops, '.', 1, stops.length);
-                    Object destination = get(key);
-                    if(destination instanceof Record) {
-                        value = ((Record) destination).map(options, path);
-                    }
-                    else if(Sequences.isSequence(destination)) {
-                        List<Object> $value = Lists.newArrayList();
-                        Sequences.forEach(destination, item -> {
-                            if(item instanceof Record) {
-                                $value.add(((Record) item).map(options, path));
-                            }
-                        });
-                        value = $value;
-                    }
-                    else {
-                        value = null;
-                    }
-                }
-                else {
-                    value = get(key);
-                }
-                return new SimpleEntry<>(key, value);
-            });
         }
         Map<String, Object> data = pool.filter(filter).collect(Association::of,
                 accumulator, MergeStrategies::upsert);
@@ -1547,8 +1558,15 @@ public abstract class Record implements Comparable<Record> {
      * This method also supports <strong>negative filtering</strong>. Prefix any
      * key with {@code -} to exclude it from the result.
      * </p>
+     * <p>
+     * It also supports <strong>additive selection</strong>. Prefix any key with
+     * {@code +} to include it on top of the defaults. The moment any bare
+     * positive key appears in {@code keys}, the defaults are dropped and only
+     * the listed keys (bare or {@code +}-prefixed) appear in the result.
+     * </p>
      *
-     * @param keys the keys to include (or exclude with {@code -} prefix)
+     * @param keys the keys to include (use {@code +} to add to defaults or
+     *            {@code -} to exclude)
      * @return the data in this {@link Record}
      */
     public Map<String, Object> map(String... keys) {
@@ -2701,12 +2719,60 @@ public abstract class Record implements Comparable<Record> {
     }
 
     /**
+     * Resolve a single positively named {@code key} into the {@link Entry} that
+     * will be contributed to a {@link #map} result.
+     * <p>
+     * For a bare key, the {@link Entry} is {@code (key, get(key))}. For a
+     * navigation key (e.g., {@code "company.name"}), the {@link Entry} is keyed
+     * by the root and valued by the nested {@code Map} (or list of nested
+     * {@code Map Maps} for a sequence-valued destination) produced by
+     * recursively materializing the remaining path on the linked {@link Record
+     * Records}. A non-navigable destination resolves to {@code null}.
+     * </p>
+     *
+     * @param key the (possibly navigation) key to resolve
+     * @param options the {@link SerializationOptions} threaded into any
+     *            recursive {@link #map} call along a navigation path
+     * @return the resolved {@link Entry}; never {@code null}, though its value
+     *         may be
+     */
+    private Entry<String, Object> resolveEntry(String key,
+            SerializationOptions options) {
+        Object value;
+        String[] stops = key.split("\\.");
+        if(stops.length > 1) {
+            key = stops[0];
+            String path = StringUtils.join(stops, '.', 1, stops.length);
+            Object destination = get(key);
+            if(destination instanceof Record) {
+                value = ((Record) destination).map(options, path);
+            }
+            else if(Sequences.isSequence(destination)) {
+                List<Object> $value = Lists.newArrayList();
+                Sequences.forEach(destination, item -> {
+                    if(item instanceof Record) {
+                        $value.add(((Record) item).map(options, path));
+                    }
+                });
+                value = $value;
+            }
+            else {
+                value = null;
+            }
+        }
+        else {
+            value = get(key);
+        }
+        return new SimpleEntry<>(key, value);
+    }
+
+    /**
      * Return a map that contains all "readable" data in this {@link Record}.
      * <p>
      * To get access to non-readable fields, use the
      * {@link #navigate(String...)} method.
      * </p>
-     * 
+     *
      * @return the data in this {@link Record}
      */
     private Map<String, Object> data() {

--- a/src/main/java/com/cinchapi/runway/Record.java
+++ b/src/main/java/com/cinchapi/runway/Record.java
@@ -1506,9 +1506,12 @@ public abstract class Record implements Comparable<Record> {
             // this branch so the call retains whitelist intent. Strip
             // excluded keys before resolution so #resolveEntry never
             // fires a @Computed supplier (or navigates a link) for an
-            // entry the downstream #filter would discard. Same end
-            // result, no wasted work.
-            List<String> whitelist = Lists.newArrayList(bare);
+            // entry the downstream #filter would discard. The
+            // LinkedHashSet collapses any bare/additive overlap so a
+            // key the caller named both ways resolves once &mdash; the
+            // "+" annotation is redundant in whitelist mode and must
+            // not double-fire a supplier or re-load a linked record.
+            Set<String> whitelist = new LinkedHashSet<>(bare);
             whitelist.addAll(additive);
             whitelist.removeAll(exclude);
             pool = whitelist.stream().map(key -> resolveEntry(key, options));

--- a/src/main/java/com/cinchapi/runway/Record.java
+++ b/src/main/java/com/cinchapi/runway/Record.java
@@ -1502,11 +1502,15 @@ public abstract class Record implements Comparable<Record> {
         Stream<Entry<String, Object>> pool;
         if(!bare.isEmpty()) {
             // Whitelist mode. A bare positive in the call &mdash; even
-            // one the caller also excluded with `-` &mdash; forces this
-            // branch so the call retains whitelist intent; the
-            // downstream #filter applies any same-named exclude.
+            // one the caller also excluded with `-` &mdash; forces
+            // this branch so the call retains whitelist intent. Strip
+            // excluded keys before resolution so #resolveEntry never
+            // fires a @Computed supplier (or navigates a link) for an
+            // entry the downstream #filter would discard. Same end
+            // result, no wasted work.
             List<String> whitelist = Lists.newArrayList(bare);
             whitelist.addAll(additive);
+            whitelist.removeAll(exclude);
             pool = whitelist.stream().map(key -> resolveEntry(key, options));
         }
         else if(!additive.isEmpty()) {

--- a/src/main/java/com/cinchapi/runway/Record.java
+++ b/src/main/java/com/cinchapi/runway/Record.java
@@ -2724,15 +2724,15 @@ public abstract class Record implements Comparable<Record> {
      * <p>
      * For a bare key, the {@link Entry} is {@code (key, get(key))}. For a
      * navigation key (e.g., {@code "company.name"}), the {@link Entry} is keyed
-     * by the root and valued by the nested {@code Map} (or list of nested
-     * {@code Map Maps} for a sequence-valued destination) produced by
-     * recursively materializing the remaining path on the linked {@link Record
-     * Records}. A non-navigable destination resolves to {@code null}.
+     * by the root and valued by the nested {@link Map} (or list of nested
+     * {@link Map Maps} for a sequence-valued destination) representing the
+     * navigation path's value on the linked {@link Record Records}. A
+     * non-navigable destination resolves to {@code null}.
      * </p>
      *
      * @param key the (possibly navigation) key to resolve
-     * @param options the {@link SerializationOptions} threaded into any
-     *            recursive {@link #map} call along a navigation path
+     * @param options the {@link SerializationOptions} applied along any
+     *            navigation path
      * @return the resolved {@link Entry}; never {@code null}, though its value
      *         may be
      */

--- a/src/main/java/com/cinchapi/runway/Record.java
+++ b/src/main/java/com/cinchapi/runway/Record.java
@@ -97,6 +97,7 @@ import com.cinchapi.runway.db.Saver;
 import com.cinchapi.runway.json.JsonTypeWriter;
 import com.cinchapi.runway.util.BackupReadSourcesHashMap;
 import com.cinchapi.runway.util.ComputedEntry;
+import com.cinchapi.runway.util.KeySelection;
 import com.cinchapi.runway.validation.Validator;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -1473,20 +1474,10 @@ public abstract class Record implements Comparable<Record> {
      */
     public Map<String, Object> map(SerializationOptions options,
             String... keys) {
-        List<String> bare = Lists.newArrayList();
-        List<String> additive = Lists.newArrayList();
-        List<String> exclude = Lists.newArrayList();
-        for (String key : keys) {
-            if(key.startsWith("-")) {
-                exclude.add(key.substring(1));
-            }
-            else if(key.startsWith("+")) {
-                additive.add(key.substring(1));
-            }
-            else {
-                bare.add(key);
-            }
-        }
+        KeySelection.Partition selection = KeySelection.partition(keys);
+        List<String> bare = selection.bare();
+        List<String> additive = selection.additive();
+        List<String> exclude = selection.exclude();
         Predicate<Entry<String, Object>> filter = entry -> !exclude
                 .contains(entry.getKey());
         if(!options.serializeNullValues()) {
@@ -1508,22 +1499,27 @@ public abstract class Record implements Comparable<Record> {
                 map.put(entry.getKey(), value);
             }
         };
-        // Pre-filter the positive lists against #exclude so the resolver
-        // never fires a @Computed supplier (or navigates a link) for a
-        // key the caller has also excluded.
-        bare.removeAll(exclude);
-        additive.removeAll(exclude);
         Stream<Entry<String, Object>> pool;
         if(!bare.isEmpty()) {
+            // Whitelist mode. A bare positive in the call &mdash; even
+            // one the caller also excluded with `-` &mdash; forces this
+            // branch so the call retains whitelist intent; the
+            // downstream #filter applies any same-named exclude.
             List<String> whitelist = Lists.newArrayList(bare);
             whitelist.addAll(additive);
             pool = whitelist.stream().map(key -> resolveEntry(key, options));
         }
         else if(!additive.isEmpty()) {
-            // Skip a baseline entry only when an additive names its bare
-            // root; navigation additives like "+a.b" must let the baseline
-            // remain so the slice upserts into the nested map rather than
-            // replacing the rest of the root's contents.
+            // Additive mode. Skip a baseline entry only when an additive
+            // names its bare root (no navigation suffix). For "+tags",
+            // the additive contributes the same key the baseline already
+            // has, so skipping here keeps the additive authoritative
+            // without running the same value through the accumulator
+            // twice. Navigation additives like "+a.b" leave the baseline
+            // alone; the slice (a Map keyed by the navigation suffix)
+            // replaces the baseline's raw value via
+            // MergeStrategies::upsert, so the result is the same either
+            // way.
             Set<String> bareAdditiveRoots = additive.stream()
                     .filter(k -> !k.contains(".")).collect(Collectors.toSet());
             Stream<Entry<String, Object>> baseline = data().entrySet().stream();
@@ -2734,7 +2730,8 @@ public abstract class Record implements Comparable<Record> {
      * @param options the {@link SerializationOptions} applied along any
      *            navigation path
      * @return the resolved {@link Entry}; never {@code null}, though its value
-     *         may be
+     *         may be {@code null} when the navigation destination is
+     *         non-navigable
      */
     private Entry<String, Object> resolveEntry(String key,
             SerializationOptions options) {

--- a/src/main/java/com/cinchapi/runway/access/Audience.java
+++ b/src/main/java/com/cinchapi/runway/access/Audience.java
@@ -416,10 +416,9 @@ public interface Audience extends DatabaseInterface {
                     // audience's allowlist) appear in the result. When
                     // the user only uses + or -, #readable plays the
                     // role of "defaults" for the audience: the result
-                    // is (allowed − userNegative) ∪ allowed-additives.
-                    // Without this expansion, passing - or + through to
-                    // subject.map would let Record#map's defaults branch
-                    // include fields the audience cannot see.
+                    // is (allowed − userNegative) ∪ allowed-additives,
+                    // so the audience's allowlist still bounds the
+                    // result.
                     Set<String> userBare = new HashSet<>();
                     Set<String> userAdditive = new HashSet<>();
                     Set<String> userNegative = new HashSet<>();

--- a/src/main/java/com/cinchapi/runway/access/Audience.java
+++ b/src/main/java/com/cinchapi/runway/access/Audience.java
@@ -26,7 +26,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -407,17 +406,6 @@ public interface Audience extends DatabaseInterface {
             // whitelist intent.
             userAdditive.removeAll(userNegative);
             userAdditive.removeAll(userBare);
-            Function<String, String> withPrefix = k -> {
-                if(userAdditive.contains(k)) {
-                    return "+" + k;
-                }
-                else if(userNegative.contains(k)) {
-                    return "-" + k;
-                }
-                else {
-                    return k;
-                }
-            };
             /*
              * Determine the keys to map based on what is requested and what is
              * readable for the #audience.
@@ -454,8 +442,19 @@ public interface Audience extends DatabaseInterface {
                 }
                 else if(!requested.equals(ALL_KEYS)
                         && readable.equals(ALL_KEYS)) {
-                    String[] visible = requested.stream().map(withPrefix)
-                            .toArray(String[]::new);
+                    // No access restrictions; forward the caller's keys
+                    // to subject.map verbatim, stripped only of any
+                    // navigation suffix (the recursive descent below
+                    // handles those). Walking the caller's input
+                    // instead of #requested preserves every prefix
+                    // combination the caller wrote on a given root, so
+                    // multi-prefix calls like frame({"x", "-x"}) round-
+                    // trip through subject.map's own precedence rules
+                    // and produce the same result as Record#map.
+                    String[] visible = keys.stream().map(k -> {
+                        int dot = k.indexOf('.');
+                        return dot < 0 ? k : k.substring(0, dot);
+                    }).distinct().toArray(String[]::new);
                     data = subject.map(options, visible);
                 }
                 else {
@@ -506,8 +505,17 @@ public interface Audience extends DatabaseInterface {
                     // mode &mdash; re-attaching `+` would reopen
                     // additive mode on the subject and re-introduce the
                     // subject's full defaults, bypassing the audience
-                    // allowlist.
-                    String[] visible = selected.toArray(Array.containing());
+                    // allowlist. Re-attach `-` for any selected key the
+                    // caller also wrote as a negative so subject.map's
+                    // exclude filter applies it inside whitelist mode;
+                    // omitting these would silently drop the caller's
+                    // negative when the same key is also in #userBare.
+                    String[] visible = Stream
+                            .concat(selected.stream(),
+                                    selected.stream()
+                                            .filter(userNegative::contains)
+                                            .map(k -> "-" + k))
+                            .toArray(String[]::new);
                     if(visible.length == 0) {
                         // No keys are visible, but don't call Record#map
                         // with an empty array because doing so will return

--- a/src/main/java/com/cinchapi/runway/access/Audience.java
+++ b/src/main/java/com/cinchapi/runway/access/Audience.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -43,6 +44,7 @@ import com.cinchapi.runway.Record;
 import com.cinchapi.runway.Selection;
 import com.cinchapi.runway.Selections;
 import com.cinchapi.runway.SerializationOptions;
+import com.cinchapi.runway.util.KeySelection;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multiset;
@@ -309,11 +311,39 @@ public interface Audience extends DatabaseInterface {
      * <li>Non-navigable values return {@code null} when nested access is
      * attempted</li>
      * </ul>
+     * <h3>Key Prefix Conventions</h3>
+     * <p>
+     * Each entry in {@code keys} accepts the same prefix conventions as
+     * {@link Record#map(SerializationOptions, String...) Record#map}:
+     * </p>
+     * <ul>
+     * <li><strong>Bare</strong> &mdash; a key with no prefix is a positive
+     * request that triggers whitelist mode; the result contains only the named
+     * keys (intersected with what this {@link Audience} is permitted to
+     * read).</li>
+     * <li><strong>Additive ({@code +})</strong> &mdash; a key prefixed with
+     * {@code +} is layered on top of the defaults the {@link Audience} is
+     * allowed to see, without dropping them. When the call mixes a bare
+     * positive with {@code +}-prefixed keys, the bare positive forces whitelist
+     * mode and the {@code +} prefix degrades to a redundant whitelist
+     * annotation.</li>
+     * <li><strong>Exclude ({@code -})</strong> &mdash; a key prefixed with
+     * {@code -} is filtered out of the result. Exclusion always wins over
+     * addition for the same key.</li>
+     * </ul>
+     * <p>
+     * <strong>NOTE:</strong> A {@code +}-prefixed key cannot bypass access
+     * control. If the audience is not permitted to read the underlying field,
+     * the key is dropped at the intersection check and
+     * {@link RestrictedAccessException} signalling (via
+     * {@link #read(Collection, Record) read}) still fires.
+     * </p>
      *
      * @param options the {@link SerializationOptions} to apply when
      *            materializing data from the {@code subject} and any linked
      *            {@link Record Records} encountered during recursive framing
-     * @param keys the fields to read from
+     * @param keys the fields to read from; entries may use {@code +} to layer
+     *            on top of the audience's defaults or {@code -} to exclude
      * @param subject the {@link Record} to read from
      * @param <T> the type of the {@link Record}
      * @return a map of visible data or {@code null} if the {@code subject} is
@@ -333,21 +363,33 @@ public interface Audience extends DatabaseInterface {
             // Break up navigation keys into root components that must be
             // resolved in this Record to their subsequent stops that must
             // be resolved in linked Records. Strip any leading + or - from
-            // the root so the access-control intersection below matches
+            // each root so the access-control intersection below matches
             // against bare field names in the audience's readable set;
-            // remember the prefix character in #prefixByRoot so the
-            // visible array re-attaches it on just the bare root (not the
-            // navigation path) when delegating to subject.map.
+            // categorize the bare root into one of three prefix buckets
+            // so the visible array can re-attach the prefix on just the
+            // root (not the navigation suffix) when delegating to
+            // subject.map. Populating the buckets during the iteration
+            // (instead of via a single map keyed by root) keeps the
+            // categorization order-independent when the caller supplies
+            // the same root under multiple prefixes.
             Map<String, Set<String>> roots = new HashMap<>();
-            Map<String, String> prefixByRoot = new HashMap<>();
+            Set<String> userBare = new HashSet<>();
+            Set<String> userAdditive = new HashSet<>();
+            Set<String> userNegative = new HashSet<>();
             for (String key : keys) {
                 String[] toks = key.split("\\.");
                 String root = toks[0];
-                String prefix = "";
-                String bareRoot = root;
-                if(root.startsWith("+") || root.startsWith("-")) {
-                    prefix = root.substring(0, 1);
-                    bareRoot = root.substring(1);
+                String bareRoot = KeySelection.stripPrefix(root);
+                switch (KeySelection.kindOf(root)) {
+                case BARE:
+                    userBare.add(bareRoot);
+                    break;
+                case ADDITIVE:
+                    userAdditive.add(bareRoot);
+                    break;
+                case EXCLUDE:
+                    userNegative.add(bareRoot);
+                    break;
                 }
                 String next = Stream.of(toks).skip(1)
                         .collect(Collectors.joining("."));
@@ -356,8 +398,26 @@ public interface Audience extends DatabaseInterface {
                 if(!next.isEmpty()) {
                     nexts.add(next);
                 }
-                prefixByRoot.put(bareRoot, prefix);
             }
+            // Apply prefix precedence to deduplicate keys the caller
+            // supplied under more than one prefix. Exclusion wins over
+            // addition so a downstream resolver never fires for a key
+            // the caller also excluded; a bare positive subsumes a `+`
+            // on the same root since the bare presence already forces
+            // whitelist intent.
+            userAdditive.removeAll(userNegative);
+            userAdditive.removeAll(userBare);
+            Function<String, String> withPrefix = k -> {
+                if(userAdditive.contains(k)) {
+                    return "+" + k;
+                }
+                else if(userNegative.contains(k)) {
+                    return "-" + k;
+                }
+                else {
+                    return k;
+                }
+            };
             /*
              * Determine the keys to map based on what is requested and what is
              * readable for the #audience.
@@ -394,8 +454,7 @@ public interface Audience extends DatabaseInterface {
                 }
                 else if(!requested.equals(ALL_KEYS)
                         && readable.equals(ALL_KEYS)) {
-                    String[] visible = requested.stream()
-                            .map(k -> prefixByRoot.getOrDefault(k, "") + k)
+                    String[] visible = requested.stream().map(withPrefix)
                             .toArray(String[]::new);
                     data = subject.map(options, visible);
                 }
@@ -410,32 +469,14 @@ public interface Audience extends DatabaseInterface {
                             allowed.add(key);
                         }
                     }
-                    // Categorize the user's request by prefix. When any
-                    // bare positive is named the call has whitelist
-                    // intent and only the named keys (filtered by the
-                    // audience's allowlist) appear in the result. When
-                    // the user only uses + or -, #readable plays the
-                    // role of "defaults" for the audience: the result
-                    // is (allowed − userNegative) ∪ allowed-additives,
-                    // so the audience's allowlist still bounds the
-                    // result.
-                    Set<String> userBare = new HashSet<>();
-                    Set<String> userAdditive = new HashSet<>();
-                    Set<String> userNegative = new HashSet<>();
-                    for (Map.Entry<String, String> entry : prefixByRoot
-                            .entrySet()) {
-                        String bareRoot = entry.getKey();
-                        String prefix = entry.getValue();
-                        if("-".equals(prefix)) {
-                            userNegative.add(bareRoot);
-                        }
-                        else if("+".equals(prefix)) {
-                            userAdditive.add(bareRoot);
-                        }
-                        else {
-                            userBare.add(bareRoot);
-                        }
-                    }
+                    // When any bare positive is named the call has
+                    // whitelist intent and only the named keys
+                    // (filtered by the audience's allowlist) appear in
+                    // the result. When the user only uses + or -,
+                    // #readable plays the role of "defaults" for the
+                    // audience: the result is (allowed − userNegative)
+                    // ∪ allowed-additives, so the audience's allowlist
+                    // still bounds the result.
                     Set<String> selected;
                     if(!userBare.isEmpty()) {
                         selected = new HashSet<>(userBare);
@@ -459,9 +500,14 @@ public interface Audience extends DatabaseInterface {
                     if(honored < requestedPositives) {
                         RESTRICTED_ACCESS_DETECTED.set(true);
                     }
-                    String[] visible = selected.stream()
-                            .map(k -> prefixByRoot.getOrDefault(k, "") + k)
-                            .toArray(String[]::new);
+                    // After access filtering, #selected is already the
+                    // exact set of keys the audience permits. Pass them
+                    // as bare positives so subject.map runs whitelist
+                    // mode &mdash; re-attaching `+` would reopen
+                    // additive mode on the subject and re-introduce the
+                    // subject's full defaults, bypassing the audience
+                    // allowlist.
+                    String[] visible = selected.toArray(Array.containing());
                     if(visible.length == 0) {
                         // No keys are visible, but don't call Record#map
                         // with an empty array because doing so will return

--- a/src/main/java/com/cinchapi/runway/access/Audience.java
+++ b/src/main/java/com/cinchapi/runway/access/Audience.java
@@ -511,7 +511,7 @@ public interface Audience extends DatabaseInterface {
                     }
                     else {
                         // Allowlist with optional denials. The
-                        // audience's "defaults" are (allowed −
+                        // audience's "defaults" are (allowed -
                         // denied); apply the caller's negatives and
                         // layer in their additives that the audience
                         // permits.

--- a/src/main/java/com/cinchapi/runway/access/Audience.java
+++ b/src/main/java/com/cinchapi/runway/access/Audience.java
@@ -359,53 +359,18 @@ public interface Audience extends DatabaseInterface {
         }
         else if(subject instanceof AccessControl) {
             AccessControl gated = (AccessControl) subject;
-            // Break up navigation keys into root components that must be
-            // resolved in this Record to their subsequent stops that must
-            // be resolved in linked Records. Strip any leading + or - from
-            // each root so the access-control intersection below matches
-            // against bare field names in the audience's readable set;
-            // categorize the bare root into one of three prefix buckets
-            // so the visible array can re-attach the prefix on just the
-            // root (not the navigation suffix) when delegating to
-            // subject.map. Populating the buckets during the iteration
-            // (instead of via a single map keyed by root) keeps the
-            // categorization order-independent when the caller supplies
-            // the same root under multiple prefixes.
-            Map<String, Set<String>> roots = new HashMap<>();
-            Set<String> userBare = new HashSet<>();
-            Set<String> userAdditive = new HashSet<>();
-            Set<String> userNegative = new HashSet<>();
-            for (String key : keys) {
-                String[] toks = key.split("\\.");
-                String root = toks[0];
-                String bareRoot = KeySelection.stripPrefix(root);
-                switch (KeySelection.kindOf(root)) {
-                case BARE:
-                    userBare.add(bareRoot);
-                    break;
-                case ADDITIVE:
-                    userAdditive.add(bareRoot);
-                    break;
-                case EXCLUDE:
-                    userNegative.add(bareRoot);
-                    break;
-                }
-                String next = Stream.of(toks).skip(1)
-                        .collect(Collectors.joining("."));
-                Set<String> nexts = roots.computeIfAbsent(bareRoot,
-                        $ -> new HashSet<>());
-                if(!next.isEmpty()) {
-                    nexts.add(next);
-                }
-            }
-            // Apply prefix precedence to deduplicate keys the caller
-            // supplied under more than one prefix. Exclusion wins over
-            // addition so a downstream resolver never fires for a key
-            // the caller also excluded; a bare positive subsumes a `+`
-            // on the same root since the bare presence already forces
-            // whitelist intent.
-            userAdditive.removeAll(userNegative);
-            userAdditive.removeAll(userBare);
+            // Bucket each requested key by the prefix on its root and
+            // track navigation suffixes per bare root for the
+            // recursive descent below. KeySelection.partitionByRoot
+            // applies the "exclusion wins over addition" precedence
+            // so a downstream resolver never fires for a key the
+            // caller has also excluded.
+            KeySelection.RootedPartition parsed = KeySelection
+                    .partitionByRoot(keys);
+            Set<String> userBare = parsed.bare();
+            Set<String> userAdditive = parsed.additive();
+            Set<String> userNegative = parsed.exclude();
+            Map<String, Set<String>> roots = parsed.navigation();
             /*
              * Determine the keys to map based on what is requested and what is
              * readable for the #audience.

--- a/src/main/java/com/cinchapi/runway/access/Audience.java
+++ b/src/main/java/com/cinchapi/runway/access/Audience.java
@@ -433,62 +433,117 @@ public interface Audience extends DatabaseInterface {
                             allowed.add(key);
                         }
                     }
-                    // When any bare positive is named the call has
-                    // whitelist intent and only the named keys
-                    // (filtered by the audience's allowlist) appear in
-                    // the result. When the user only uses + or -,
-                    // #readable plays the role of "defaults" for the
-                    // audience: the result is (allowed − userNegative)
-                    // ∪ allowed-additives, so the audience's allowlist
-                    // still bounds the result.
-                    Set<String> selected;
+                    // A denylist-only readable rule (empty #allowed,
+                    // non-empty #denied) permits every subject key
+                    // minus the denied entries &mdash; the
+                    // empty-allowlist-as-wildcard semantic enforced by
+                    // AccessControlSupport#isPermittedAccess. Skip the
+                    // allowlist gate in that mode; #denied still
+                    // bounds the result.
+                    boolean denylistOnly = allowed.isEmpty();
+                    int requestedPositives = userBare.size()
+                            + userAdditive.size();
                     if(!userBare.isEmpty()) {
-                        selected = new HashSet<>(userBare);
+                        // Whitelist intent: only the named keys (bare
+                        // and `+`-prefixed) appear, gated by the
+                        // allowlist (skipped under denylist-only) and
+                        // by #denied. Reattach `-` for any selected
+                        // key the caller also wrote as a negative so
+                        // subject.map's exclude filter applies inside
+                        // whitelist mode.
+                        Set<String> selected = new HashSet<>(userBare);
                         selected.addAll(userAdditive);
-                        selected.removeIf(k -> !allowed.contains(k)
-                                || denied.contains(k));
+                        selected.removeIf(
+                                k -> (!denylistOnly && !allowed.contains(k))
+                                        || denied.contains(k));
+                        long honored = Stream
+                                .concat(userBare.stream(),
+                                        userAdditive.stream())
+                                .filter(selected::contains).count();
+                        if(honored < requestedPositives) {
+                            RESTRICTED_ACCESS_DETECTED.set(true);
+                        }
+                        String[] visible = Stream.concat(selected.stream(),
+                                selected.stream().filter(userNegative::contains)
+                                        .map(k -> "-" + k))
+                                .toArray(String[]::new);
+                        if(visible.length == 0) {
+                            // No keys are visible, but don't call
+                            // Record#map with an empty array because
+                            // doing so will return all data
+                            data = new HashMap<>();
+                        }
+                        else {
+                            data = subject.map(options, visible);
+                        }
+                    }
+                    else if(denylistOnly) {
+                        // No bare positives and no allowlist. The
+                        // audience permits every subject key except
+                        // #denied, so delegate to subject.map in
+                        // defaults/additive mode with the caller's
+                        // additives plus the union of user-negatives
+                        // and audience-denials reattached as `-`
+                        // excludes. An additive on a denied key is
+                        // dropped and the call is flagged as
+                        // restricted.
+                        long honored = Stream
+                                .concat(userBare.stream(),
+                                        userAdditive.stream())
+                                .filter(k -> !denied.contains(k)).count();
+                        if(honored < requestedPositives) {
+                            RESTRICTED_ACCESS_DETECTED.set(true);
+                        }
+                        Set<String> excludes = new HashSet<>(userNegative);
+                        excludes.addAll(denied);
+                        String[] visible = Stream
+                                .concat(userAdditive.stream()
+                                        .filter(k -> !denied.contains(k))
+                                        .map(k -> "+" + k),
+                                        excludes.stream().map(k -> "-" + k))
+                                .toArray(String[]::new);
+                        if(visible.length == 0) {
+                            data = subject.map(options);
+                        }
+                        else {
+                            data = subject.map(options, visible);
+                        }
                     }
                     else {
-                        selected = new HashSet<>(allowed);
+                        // Allowlist with optional denials. The
+                        // audience's "defaults" are (allowed −
+                        // denied); apply the caller's negatives and
+                        // layer in their additives that the audience
+                        // permits.
+                        Set<String> selected = new HashSet<>(allowed);
                         selected.removeAll(denied);
                         selected.removeAll(userNegative);
                         userAdditive.stream().filter(allowed::contains)
                                 .filter(k -> !denied.contains(k))
                                 .forEach(selected::add);
-                    }
-                    int requestedPositives = userBare.size()
-                            + userAdditive.size();
-                    long honored = Stream
-                            .concat(userBare.stream(), userAdditive.stream())
-                            .filter(selected::contains).count();
-                    if(honored < requestedPositives) {
-                        RESTRICTED_ACCESS_DETECTED.set(true);
-                    }
-                    // After access filtering, #selected is already the
-                    // exact set of keys the audience permits. Pass them
-                    // as bare positives so subject.map runs whitelist
-                    // mode &mdash; re-attaching `+` would reopen
-                    // additive mode on the subject and re-introduce the
-                    // subject's full defaults, bypassing the audience
-                    // allowlist. Re-attach `-` for any selected key the
-                    // caller also wrote as a negative so subject.map's
-                    // exclude filter applies it inside whitelist mode;
-                    // omitting these would silently drop the caller's
-                    // negative when the same key is also in #userBare.
-                    String[] visible = Stream
-                            .concat(selected.stream(),
-                                    selected.stream()
-                                            .filter(userNegative::contains)
-                                            .map(k -> "-" + k))
-                            .toArray(String[]::new);
-                    if(visible.length == 0) {
-                        // No keys are visible, but don't call Record#map
-                        // with an empty array because doing so will return
-                        // all data
-                        data = new HashMap<>();
-                    }
-                    else {
-                        data = subject.map(options, visible);
+                        long honored = Stream
+                                .concat(userBare.stream(),
+                                        userAdditive.stream())
+                                .filter(selected::contains).count();
+                        if(honored < requestedPositives) {
+                            RESTRICTED_ACCESS_DETECTED.set(true);
+                        }
+                        // Pass the audience-permitted set as bare
+                        // positives so subject.map runs whitelist mode
+                        // &mdash; reattaching `+` would reopen
+                        // additive mode on the subject and bypass the
+                        // allowlist. Reattach `-` for any selected
+                        // key the caller also wrote as a negative.
+                        String[] visible = Stream.concat(selected.stream(),
+                                selected.stream().filter(userNegative::contains)
+                                        .map(k -> "-" + k))
+                                .toArray(String[]::new);
+                        if(visible.length == 0) {
+                            data = new HashMap<>();
+                        }
+                        else {
+                            data = subject.map(options, visible);
+                        }
                     }
                 }
             }

--- a/src/main/java/com/cinchapi/runway/access/Audience.java
+++ b/src/main/java/com/cinchapi/runway/access/Audience.java
@@ -332,20 +332,31 @@ public interface Audience extends DatabaseInterface {
             AccessControl gated = (AccessControl) subject;
             // Break up navigation keys into root components that must be
             // resolved in this Record to their subsequent stops that must
-            // be resolved in linked Records
+            // be resolved in linked Records. Strip any leading + or - from
+            // the root so the access-control intersection below matches
+            // against bare field names in the audience's readable set;
+            // remember the prefix character in #prefixByRoot so the
+            // visible array re-attaches it on just the bare root (not the
+            // navigation path) when delegating to subject.map.
             Map<String, Set<String>> roots = new HashMap<>();
+            Map<String, String> prefixByRoot = new HashMap<>();
             for (String key : keys) {
                 String[] toks = key.split("\\.");
-                // Handle negative rules: negative keys apply only to the
-                // root level and are not distributed to nested paths
                 String root = toks[0];
+                String prefix = "";
+                String bareRoot = root;
+                if(root.startsWith("+") || root.startsWith("-")) {
+                    prefix = root.substring(0, 1);
+                    bareRoot = root.substring(1);
+                }
                 String next = Stream.of(toks).skip(1)
                         .collect(Collectors.joining("."));
-                Set<String> nexts = roots.computeIfAbsent(root,
+                Set<String> nexts = roots.computeIfAbsent(bareRoot,
                         $ -> new HashSet<>());
                 if(!next.isEmpty()) {
                     nexts.add(next);
                 }
+                prefixByRoot.put(bareRoot, prefix);
             }
             /*
              * Determine the keys to map based on what is requested and what is
@@ -383,7 +394,9 @@ public interface Audience extends DatabaseInterface {
                 }
                 else if(!requested.equals(ALL_KEYS)
                         && readable.equals(ALL_KEYS)) {
-                    String[] visible = requested.toArray(Array.containing());
+                    String[] visible = requested.stream()
+                            .map(k -> prefixByRoot.getOrDefault(k, "") + k)
+                            .toArray(String[]::new);
                     data = subject.map(options, visible);
                 }
                 else {
@@ -397,13 +410,59 @@ public interface Audience extends DatabaseInterface {
                             allowed.add(key);
                         }
                     }
-                    String[] visible = requested.stream().filter(
-                            key -> allowed.isEmpty() || allowed.contains(key))
-                            .filter(key -> !denied.contains(key))
-                            .toArray(String[]::new);
-                    if(visible.length < requested.size()) {
+                    // Categorize the user's request by prefix. When any
+                    // bare positive is named the call has whitelist
+                    // intent and only the named keys (filtered by the
+                    // audience's allowlist) appear in the result. When
+                    // the user only uses + or -, #readable plays the
+                    // role of "defaults" for the audience: the result
+                    // is (allowed − userNegative) ∪ allowed-additives.
+                    // Without this expansion, passing - or + through to
+                    // subject.map would let Record#map's defaults branch
+                    // include fields the audience cannot see.
+                    Set<String> userBare = new HashSet<>();
+                    Set<String> userAdditive = new HashSet<>();
+                    Set<String> userNegative = new HashSet<>();
+                    for (Map.Entry<String, String> entry : prefixByRoot
+                            .entrySet()) {
+                        String bareRoot = entry.getKey();
+                        String prefix = entry.getValue();
+                        if("-".equals(prefix)) {
+                            userNegative.add(bareRoot);
+                        }
+                        else if("+".equals(prefix)) {
+                            userAdditive.add(bareRoot);
+                        }
+                        else {
+                            userBare.add(bareRoot);
+                        }
+                    }
+                    Set<String> selected;
+                    if(!userBare.isEmpty()) {
+                        selected = new HashSet<>(userBare);
+                        selected.addAll(userAdditive);
+                        selected.removeIf(k -> !allowed.contains(k)
+                                || denied.contains(k));
+                    }
+                    else {
+                        selected = new HashSet<>(allowed);
+                        selected.removeAll(denied);
+                        selected.removeAll(userNegative);
+                        userAdditive.stream().filter(allowed::contains)
+                                .filter(k -> !denied.contains(k))
+                                .forEach(selected::add);
+                    }
+                    int requestedPositives = userBare.size()
+                            + userAdditive.size();
+                    long honored = Stream
+                            .concat(userBare.stream(), userAdditive.stream())
+                            .filter(selected::contains).count();
+                    if(honored < requestedPositives) {
                         RESTRICTED_ACCESS_DETECTED.set(true);
                     }
+                    String[] visible = selected.stream()
+                            .map(k -> prefixByRoot.getOrDefault(k, "") + k)
+                            .toArray(String[]::new);
                     if(visible.length == 0) {
                         // No keys are visible, but don't call Record#map
                         // with an empty array because doing so will return

--- a/src/main/java/com/cinchapi/runway/util/KeySelection.java
+++ b/src/main/java/com/cinchapi/runway/util/KeySelection.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2013-2026 Cinchapi Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.cinchapi.runway.util;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import javax.annotation.concurrent.Immutable;
+
+import com.google.common.collect.Lists;
+
+/**
+ * Shared parsing for the {@code +}, {@code -}, and bare key conventions used by
+ * {@link com.cinchapi.runway.Record#map Record#map},
+ * {@link com.cinchapi.runway.Record#json Record#json}, and
+ * {@link com.cinchapi.runway.access.Audience#frame Audience#frame}.
+ * <p>
+ * A leading {@code +} marks an <em>additive</em> key (one that augments the
+ * default payload), a leading {@code -} marks an <em>exclude</em> key (one that
+ * is filtered out of the result), and any other key is <em>bare</em> (a
+ * positive key that triggers whitelist mode at the call site).
+ * </p>
+ *
+ * @author Jeff Nelson
+ */
+public final class KeySelection {
+
+    /**
+     * Classify {@code key} as a {@link Kind}.
+     *
+     * @param key the key to classify
+     * @return the {@link Kind} indicated by {@code key}'s leading character
+     */
+    public static Kind kindOf(String key) {
+        if(key.startsWith("+")) {
+            return Kind.ADDITIVE;
+        }
+        else if(key.startsWith("-")) {
+            return Kind.EXCLUDE;
+        }
+        else {
+            return Kind.BARE;
+        }
+    }
+
+    /**
+     * Return {@code key} with its leading {@code +} or {@code -} prefix
+     * removed, if present.
+     *
+     * @param key the key to strip
+     * @return {@code key} with any leading {@code +} or {@code -} removed
+     */
+    public static String stripPrefix(String key) {
+        if(key.isEmpty()) {
+            return key;
+        }
+        char c = key.charAt(0);
+        if(c == '+' || c == '-') {
+            return key.substring(1);
+        }
+        else {
+            return key;
+        }
+    }
+
+    /**
+     * Partition {@code keys} into bare, additive, and exclude buckets &mdash;
+     * with the leading {@code +} or {@code -} prefix stripped on positive and
+     * exclude entries respectively.
+     * <p>
+     * The partitioning is <strong>order-independent</strong>: the same set of
+     * input keys always produces the same buckets, regardless of the order they
+     * are iterated. When a key root appears with both {@code +} and {@code -},
+     * the {@code -} wins &mdash; the additive is dropped so a downstream
+     * resolver never fires a {@link com.cinchapi.runway.Computed @Computed}
+     * supplier (or navigates a link) for a key the caller has also excluded.
+     * The {@code -} wins both for <em>exact</em> matches ({@code +foo} vs.
+     * {@code -foo}) and for <em>root</em> matches ({@code +foo.bar} vs.
+     * {@code -foo}); the latter prevents a navigation additive from doing work
+     * on a root the caller excluded outright.
+     * </p>
+     * <p>
+     * <strong>NOTE:</strong> A bare key that also appears with {@code -}
+     * deliberately remains in {@link Partition#bare() bare} so it can still
+     * force whitelist mode at the call site. The downstream exclude filter
+     * removes it from the final result.
+     * </p>
+     *
+     * @param keys the keys to partition
+     * @return the {@link Partition}
+     */
+    public static Partition partition(Iterable<String> keys) {
+        List<String> bare = Lists.newArrayList();
+        List<String> additive = Lists.newArrayList();
+        List<String> exclude = Lists.newArrayList();
+        for (String key : keys) {
+            switch (kindOf(key)) {
+            case BARE:
+                bare.add(key);
+                break;
+            case ADDITIVE:
+                additive.add(key.substring(1));
+                break;
+            case EXCLUDE:
+                exclude.add(key.substring(1));
+                break;
+            }
+        }
+        // Exclusion wins over addition for both exact matches and root
+        // matches. Catching the root case ("+a.b" vs. "-a") prevents a
+        // navigation additive from firing #resolveEntry &mdash; loading
+        // a linked record or running a @Computed supplier &mdash; for a
+        // root the caller has already excluded outright.
+        additive.removeIf(k -> {
+            int dot = k.indexOf('.');
+            String root = dot < 0 ? k : k.substring(0, dot);
+            return exclude.contains(k) || exclude.contains(root);
+        });
+        return new Partition(bare, additive, exclude);
+    }
+
+    /**
+     * Partition {@code keys} into bare, additive, and exclude buckets.
+     *
+     * @param keys the keys to partition
+     * @return the {@link Partition}
+     * @see #partition(Iterable)
+     */
+    public static Partition partition(String... keys) {
+        return partition(Arrays.asList(keys));
+    }
+
+    private KeySelection() {/* no-init */}
+
+    /**
+     * The three categories of keys recognized by the selection prefix
+     * convention.
+     *
+     * @author Jeff Nelson
+     */
+    public enum Kind {
+
+        /**
+         * A positive key with no leading prefix. Forces whitelist mode at the
+         * call site &mdash; only the named keys appear in the result.
+         */
+        BARE,
+
+        /**
+         * A key prefixed with {@code +}. Layers on top of the defaults without
+         * dropping them.
+         */
+        ADDITIVE,
+
+        /**
+         * A key prefixed with {@code -}. Filtered out of the result.
+         */
+        EXCLUDE
+    }
+
+    /**
+     * The result of {@link #partition(Iterable) partitioning} a collection of
+     * keys by prefix.
+     *
+     * @author Jeff Nelson
+     */
+    @Immutable
+    public static final class Partition {
+
+        private final List<String> bare;
+
+        private final List<String> additive;
+
+        private final List<String> exclude;
+
+        private Partition(List<String> bare, List<String> additive,
+                List<String> exclude) {
+            this.bare = bare;
+            this.additive = additive;
+            this.exclude = exclude;
+        }
+
+        /**
+         * Return the bare positive keys &mdash; keys with no leading {@code +}
+         * or {@code -}.
+         *
+         * @return the bare keys
+         */
+        public List<String> bare() {
+            return Collections.unmodifiableList(bare);
+        }
+
+        /**
+         * Return the {@code +}-prefixed positive keys with the prefix stripped.
+         * Any key whose exact value <em>or whose root</em> also appears as
+         * {@link #exclude() an exclusion} has been removed.
+         *
+         * @return the additive keys
+         */
+        public List<String> additive() {
+            return Collections.unmodifiableList(additive);
+        }
+
+        /**
+         * Return the {@code -}-prefixed exclusion keys with the prefix
+         * stripped.
+         *
+         * @return the exclude keys
+         */
+        public List<String> exclude() {
+            return Collections.unmodifiableList(exclude);
+        }
+    }
+
+}

--- a/src/main/java/com/cinchapi/runway/util/KeySelection.java
+++ b/src/main/java/com/cinchapi/runway/util/KeySelection.java
@@ -18,10 +18,16 @@ package com.cinchapi.runway.util;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.annotation.concurrent.Immutable;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 
 /**
  * Shared parsing for the {@code +}, {@code -}, and bare key conventions used by
@@ -144,6 +150,74 @@ public final class KeySelection {
         return partition(Arrays.asList(keys));
     }
 
+    /**
+     * Partition {@code keys} into bare, additive, and exclude buckets <em>by
+     * their bare root</em>, with any navigation suffix surfaced separately as a
+     * {@link RootedPartition#navigation() navigation map}.
+     * <p>
+     * This is the root-keyed counterpart to {@link #partition(Iterable)}: each
+     * key is split on {@code .}, the leading {@code +} or {@code -} is stripped
+     * from the root, and the resulting bare root is placed in exactly one
+     * bucket determined by that prefix. Any navigation suffix (e.g.,
+     * {@code "b.c"} from {@code "+a.b.c"}) is collected under the bare root in
+     * {@link RootedPartition#navigation() navigation}.
+     * </p>
+     * <p>
+     * The partitioning is <strong>order-independent</strong>: regardless of the
+     * iteration order over {@code keys}, the resulting buckets are identical.
+     * The same exclusion-wins rule as {@link #partition(Iterable)} applies
+     * &mdash; if a bare root appears under both {@code +} and {@code -}, the
+     * additive entry is dropped. Bare roots are never filtered against
+     * exclusions; a bare positive must retain its power to force whitelist
+     * intent at the call site even when the same root is also excluded.
+     * </p>
+     *
+     * @param keys the keys to partition
+     * @return the {@link RootedPartition}
+     */
+    public static RootedPartition partitionByRoot(Iterable<String> keys) {
+        Set<String> bare = Sets.newHashSet();
+        Set<String> additive = Sets.newHashSet();
+        Set<String> exclude = Sets.newHashSet();
+        Map<String, Set<String>> navigation = Maps.newHashMap();
+        for (String key : keys) {
+            String[] toks = key.split("\\.");
+            String root = toks[0];
+            String bareRoot = stripPrefix(root);
+            switch (kindOf(root)) {
+            case BARE:
+                bare.add(bareRoot);
+                break;
+            case ADDITIVE:
+                additive.add(bareRoot);
+                break;
+            case EXCLUDE:
+                exclude.add(bareRoot);
+                break;
+            }
+            Set<String> suffixes = navigation.computeIfAbsent(bareRoot,
+                    $ -> Sets.newHashSet());
+            if(toks.length > 1) {
+                suffixes.add(Stream.of(toks).skip(1)
+                        .collect(Collectors.joining(".")));
+            }
+        }
+        additive.removeAll(exclude);
+        return new RootedPartition(bare, additive, exclude, navigation);
+    }
+
+    /**
+     * Partition {@code keys} into root-keyed bare, additive, and exclude
+     * buckets.
+     *
+     * @param keys the keys to partition
+     * @return the {@link RootedPartition}
+     * @see #partitionByRoot(Iterable)
+     */
+    public static RootedPartition partitionByRoot(String... keys) {
+        return partitionByRoot(Arrays.asList(keys));
+    }
+
     private KeySelection() {/* no-init */}
 
     /**
@@ -223,6 +297,84 @@ public final class KeySelection {
          */
         public List<String> exclude() {
             return Collections.unmodifiableList(exclude);
+        }
+    }
+
+    /**
+     * The result of {@link #partitionByRoot(Iterable) partitioning} a
+     * collection of keys by their bare root.
+     * <p>
+     * Each {@link #bare()}, {@link #additive()}, and {@link #exclude()} bucket
+     * contains bare root field names (no prefix, no navigation suffix). The
+     * {@link #navigation()} accessor surfaces, for every bare root that the
+     * caller mentioned, the set of navigation suffixes that appeared on that
+     * root &mdash; e.g., {@code partitionByRoot("+a.b", "-a.c")} produces
+     * {@code navigation = {"a" -> {"b", "c"}}}. Roots mentioned without a
+     * suffix map to an empty set, distinguishing them from roots the caller
+     * never mentioned at all (which are absent from the map).
+     * </p>
+     *
+     * @author Jeff Nelson
+     */
+    @Immutable
+    public static final class RootedPartition {
+
+        private final Set<String> bare;
+
+        private final Set<String> additive;
+
+        private final Set<String> exclude;
+
+        private final Map<String, Set<String>> navigation;
+
+        private RootedPartition(Set<String> bare, Set<String> additive,
+                Set<String> exclude, Map<String, Set<String>> navigation) {
+            this.bare = bare;
+            this.additive = additive;
+            this.exclude = exclude;
+            this.navigation = navigation;
+        }
+
+        /**
+         * Return the bare positive roots &mdash; roots whose original key had
+         * no leading {@code +} or {@code -}.
+         *
+         * @return the bare roots
+         */
+        public Set<String> bare() {
+            return Collections.unmodifiableSet(bare);
+        }
+
+        /**
+         * Return the additive roots &mdash; roots whose original key carried a
+         * leading {@code +}. Any root that also appears as {@link #exclude() an
+         * exclusion} has been removed.
+         *
+         * @return the additive roots
+         */
+        public Set<String> additive() {
+            return Collections.unmodifiableSet(additive);
+        }
+
+        /**
+         * Return the excluded roots &mdash; roots whose original key carried a
+         * leading {@code -}.
+         *
+         * @return the excluded roots
+         */
+        public Set<String> exclude() {
+            return Collections.unmodifiableSet(exclude);
+        }
+
+        /**
+         * Return a {@link Map} from each bare root the caller mentioned to the
+         * set of navigation suffixes that appeared on that root. A root with no
+         * navigation suffix maps to an empty {@link Set}.
+         *
+         * @return the navigation map
+         */
+        public Map<String, Set<String>> navigation() {
+            return Collections.unmodifiableMap(navigation);
         }
     }
 

--- a/src/main/java/com/cinchapi/runway/util/KeySelection.java
+++ b/src/main/java/com/cinchapi/runway/util/KeySelection.java
@@ -25,6 +25,7 @@ import java.util.stream.Stream;
 
 import javax.annotation.concurrent.Immutable;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -332,7 +333,15 @@ public final class KeySelection {
             this.bare = bare;
             this.additive = additive;
             this.exclude = exclude;
-            this.navigation = navigation;
+            // Snapshot the per-root suffix sets as immutable copies so
+            // the @Immutable contract holds end-to-end. Without this,
+            // navigation()'s outer-map wrapper would still hand out the
+            // live HashSets and a caller could mutate them in place.
+            Map<String, Set<String>> snapshot = Maps
+                    .newHashMapWithExpectedSize(navigation.size());
+            navigation.forEach((root, suffixes) -> snapshot.put(root,
+                    ImmutableSet.copyOf(suffixes)));
+            this.navigation = snapshot;
         }
 
         /**

--- a/src/test/java/com/cinchapi/runway/RecordAdditiveKeysTest.java
+++ b/src/test/java/com/cinchapi/runway/RecordAdditiveKeysTest.java
@@ -79,7 +79,7 @@ public class RecordAdditiveKeysTest extends RunwayBaseClientServerTest {
 
     /**
      * <strong>Goal:</strong> Verify that mixing {@code +} and {@code -} keys
-     * produces {@code (defaults − exclude) ∪ additive} and fires the computed
+     * produces {@code (defaults - exclude) + additive} and fires the computed
      * supplier exactly once.
      * <p>
      * <strong>Start state:</strong> A {@link Gadget} with {@code name} and

--- a/src/test/java/com/cinchapi/runway/RecordAdditiveKeysTest.java
+++ b/src/test/java/com/cinchapi/runway/RecordAdditiveKeysTest.java
@@ -40,9 +40,6 @@ import com.google.common.collect.ImmutableSet;
  * present; defaults are dropped and only the listed keys (bare and
  * {@code +}-prefixed alike) appear in the result, minus exclusions.</li>
  * </ul>
- * <p>
- * These tests are expected to fail prior to the implementation of GH-133 and
- * pass after.
  *
  * @author Jeff Nelson
  */

--- a/src/test/java/com/cinchapi/runway/RecordAdditiveKeysTest.java
+++ b/src/test/java/com/cinchapi/runway/RecordAdditiveKeysTest.java
@@ -1,0 +1,416 @@
+/*
+ * Copyright (c) 2013-2026 Cinchapi Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.cinchapi.runway;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableSet;
+
+/**
+ * Regression tests for the additive {@code +} key prefix on
+ * {@link Record#map(String...) map} and {@link Record#json(String...) json}.
+ * <p>
+ * The behavior under test is the three-mode dispatch:
+ * <ul>
+ * <li><strong>Defaults mode</strong> when the call has no positive keys (only
+ * {@code -}-prefixed exclusions, or no keys at all).</li>
+ * <li><strong>Additive mode</strong> when every positive key is
+ * {@code +}-prefixed; the result is defaults augmented with the additive keys,
+ * minus any exclusions.</li>
+ * <li><strong>Whitelist mode</strong> the moment any bare positive key is
+ * present; defaults are dropped and only the listed keys (bare and
+ * {@code +}-prefixed alike) appear in the result, minus exclusions.</li>
+ * </ul>
+ * <p>
+ * These tests are expected to fail prior to the implementation of GH-133 and
+ * pass after.
+ *
+ * @author Jeff Nelson
+ */
+public class RecordAdditiveKeysTest extends RunwayBaseClientServerTest {
+
+    /**
+     * <strong>Goal:</strong> Verify that {@code map("+label")} returns the
+     * default payload augmented with the {@link Computed} {@code label}
+     * property, firing the supplier exactly once.
+     * <p>
+     * <strong>Start state:</strong> A freshly constructed {@link Gadget} whose
+     * computed supplier has not yet run.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Populate {@code name} and {@code tags} on the {@link Gadget}.</li>
+     * <li>Invoke {@code gadget.map("+label")}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The result contains {@code name},
+     * {@code tags}, and the computed {@code label}; the supplier counter
+     * reflects exactly one invocation.
+     */
+    @Test
+    public void testAdditivePrefixIncludesComputedOnTopOfDefaults() {
+        Gadget gadget = new Gadget();
+        gadget.name = "alpha";
+        gadget.tags = new HashSet<>(ImmutableSet.of("x", "y"));
+
+        Map<String, Object> result = gadget.map("+label");
+
+        Assert.assertTrue("defaults include name", result.containsKey("name"));
+        Assert.assertTrue("defaults include tags", result.containsKey("tags"));
+        Assert.assertEquals("label-alpha", result.get("label"));
+        Assert.assertEquals(1, gadget.labelInvocations.get());
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that mixing {@code +} and {@code -} keys
+     * produces {@code (defaults − exclude) ∪ additive} and fires the computed
+     * supplier exactly once.
+     * <p>
+     * <strong>Start state:</strong> A {@link Gadget} with {@code name} and
+     * {@code tags} populated; supplier has not yet run.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Invoke {@code gadget.map("+label", "-name")}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The result omits {@code name}, retains
+     * {@code tags}, and includes the computed {@code label}; the supplier
+     * counter reflects exactly one invocation.
+     */
+    @Test
+    public void testAdditiveAndNegativeMix() {
+        Gadget gadget = new Gadget();
+        gadget.name = "alpha";
+        gadget.tags = new HashSet<>(ImmutableSet.of("x", "y"));
+
+        Map<String, Object> result = gadget.map("+label", "-name");
+
+        Assert.assertFalse("name excluded", result.containsKey("name"));
+        Assert.assertTrue("tags retained", result.containsKey("tags"));
+        Assert.assertEquals("label-alpha", result.get("label"));
+        Assert.assertEquals(1, gadget.labelInvocations.get());
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that {@code +} on a key already in the
+     * defaults is a no-op &mdash; the result matches the bare-defaults payload
+     * and the computed supplier never fires.
+     * <p>
+     * <strong>Start state:</strong> A {@link Gadget} with {@code name} and
+     * {@code tags} populated; supplier has not yet run.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Invoke {@code gadget.map()} to capture the baseline payload.</li>
+     * <li>Invoke {@code gadget.map("+name")}, where {@code name} is an
+     * intrinsic field already present in the defaults.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The {@code "+name"} result has the same key
+     * set as the baseline {@code map()} call and the supplier counter remains
+     * at {@code 0}.
+     */
+    @Test
+    public void testAdditiveOnIntrinsicIsNoOp() {
+        Gadget gadget = new Gadget();
+        gadget.name = "alpha";
+        gadget.tags = new HashSet<>(ImmutableSet.of("x", "y"));
+
+        Map<String, Object> baseline = gadget.map();
+        Map<String, Object> result = gadget.map("+name");
+
+        Assert.assertEquals(baseline.keySet(), result.keySet());
+        Assert.assertEquals(0, gadget.labelInvocations.get());
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that {@code +} on a Collection-typed
+     * intrinsic field does not produce a duplicated/concatenated value. This
+     * locks in the no-double-merge guarantee that motivates the narrower skip
+     * predicate in the implementation (skip baseline only for bare-root
+     * additives).
+     * <p>
+     * <strong>Start state:</strong> A {@link Gadget} whose {@code tags} set
+     * contains exactly two distinct elements.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Invoke {@code gadget.map("+tags")}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The {@code tags} entry in the result is a
+     * Collection of size {@code 2} &mdash; the same content as
+     * {@code gadget.tags}, not a concatenation that would surface size
+     * {@code 4} if both baseline and additive contributions were upserted.
+     */
+    @Test
+    public void testAdditiveOnIntrinsicCollectionDoesNotDuplicate() {
+        Gadget gadget = new Gadget();
+        gadget.name = "alpha";
+        gadget.tags = new HashSet<>(ImmutableSet.of("x", "y"));
+
+        Map<String, Object> result = gadget.map("+tags");
+
+        Object tags = result.get("tags");
+        Assert.assertTrue("tags should be a Collection",
+                tags instanceof java.util.Collection);
+        Assert.assertEquals(2, ((java.util.Collection<?>) tags).size());
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that when a key appears with both {@code +}
+     * and {@code -}, exclusion wins and the supplier does not fire.
+     * <p>
+     * <strong>Start state:</strong> A {@link Gadget} with {@code name} and
+     * {@code tags} populated; supplier has not yet run.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Invoke {@code gadget.map("+label", "-label")}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The result omits {@code label} and the
+     * supplier counter remains at {@code 0}.
+     */
+    @Test
+    public void testNegativeWinsOverAdditiveForSameKey() {
+        Gadget gadget = new Gadget();
+        gadget.name = "alpha";
+        gadget.tags = new HashSet<>(ImmutableSet.of("x", "y"));
+
+        Map<String, Object> result = gadget.map("+label", "-label");
+
+        Assert.assertFalse("label excluded by -", result.containsKey("label"));
+        Assert.assertEquals(0, gadget.labelInvocations.get());
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that a single bare positive key triggers
+     * whitelist mode &mdash; defaults are dropped &mdash; even when
+     * {@code +}-prefixed keys are also present. {@code +} in whitelist mode
+     * degrades to a redundant annotation: the key is on the whitelist, nothing
+     * more.
+     * <p>
+     * <strong>Start state:</strong> A {@link Gadget} with {@code name},
+     * {@code tags} populated; supplier has not yet run.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Invoke {@code gadget.map("+label", "name")}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The result contains exactly {@code name} and
+     * {@code label}; {@code tags} (which is in defaults but not on the
+     * whitelist) is <strong>not</strong> in the result. The supplier fires
+     * exactly once because {@code label} is on the whitelist.
+     */
+    @Test
+    public void testBareKeyWithPlusKeyIsWhitelistOnly() {
+        Gadget gadget = new Gadget();
+        gadget.name = "alpha";
+        gadget.tags = new HashSet<>(ImmutableSet.of("x", "y"));
+
+        Map<String, Object> result = gadget.map("+label", "name");
+
+        Assert.assertTrue("name on whitelist", result.containsKey("name"));
+        Assert.assertEquals("label-alpha", result.get("label"));
+        Assert.assertFalse("tags not on whitelist, defaults dropped",
+                result.containsKey("tags"));
+        Assert.assertEquals(1, gadget.labelInvocations.get());
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that the existing legacy oddity &mdash; a
+     * mix of bare and {@code -}-prefixed keys returns only the bare keys
+     * &mdash; is preserved by the three-mode dispatch. The presence of a bare
+     * positive (here, {@code "name"}) triggers whitelist mode; the
+     * {@code -}-prefixed keys become no-ops because they were never on the
+     * whitelist to begin with.
+     * <p>
+     * Mirrors {@code RecordDataAccessTest#testGetNegativeAndPositiveFiltering}
+     * but exercises the new fixture to prove the new dispatch preserves the
+     * established behavior.
+     * <p>
+     * <strong>Start state:</strong> A {@link Gadget} with {@code name},
+     * {@code tags} populated.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Invoke {@code gadget.map("-tags", "name", "-label")}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The result contains only {@code name};
+     * {@code tags} and {@code label} are absent.
+     */
+    @Test
+    public void testLegacyOddityPreservedInWhitelistMode() {
+        Gadget gadget = new Gadget();
+        gadget.name = "alpha";
+        gadget.tags = new HashSet<>(ImmutableSet.of("x", "y"));
+
+        Map<String, Object> result = gadget.map("-tags", "name", "-label");
+
+        Assert.assertTrue("name on whitelist", result.containsKey("name"));
+        Assert.assertFalse("tags not on whitelist", result.containsKey("tags"));
+        Assert.assertFalse("label not on whitelist",
+                result.containsKey("label"));
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that {@code +}-prefixed navigation keys do
+     * <strong>not</strong> erase the rest of the baseline root. This locks in
+     * the narrower-skip-predicate fix: for a navigation additive like
+     * {@code "+linkedGadget.name"}, the baseline {@code linkedGadget} entry
+     * must remain in the pool so the navigation slice merges into it rather
+     * than replacing it.
+     * <p>
+     * <strong>Start state:</strong> A {@link Gadget} with a non-null
+     * {@code linkedGadget} that has both {@code name} and {@code tags}
+     * populated.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Invoke {@code gadget.map("+linkedGadget.name")}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The result contains the outer record's
+     * defaults ({@code name}, {@code tags}) and contains a non-null
+     * {@code linkedGadget} entry. The result also has a way to surface the
+     * linked record's {@code name} &mdash; whether via the link being expanded
+     * inline or via the merged navigation slice. The test asserts the
+     * conservative invariant that the outer defaults survive and the
+     * {@code linkedGadget} key is present.
+     */
+    @Test
+    public void testAdditiveNavigationKeyPreservesBaselineRoot() {
+        Gadget linked = new Gadget();
+        linked.name = "linked-alpha";
+        linked.tags = new HashSet<>(ImmutableSet.of("z"));
+
+        Gadget gadget = new Gadget();
+        gadget.name = "alpha";
+        gadget.tags = new HashSet<>(ImmutableSet.of("x", "y"));
+        gadget.linkedGadget = linked;
+
+        Map<String, Object> result = gadget.map("+linkedGadget.name");
+
+        Assert.assertTrue("outer name preserved", result.containsKey("name"));
+        Assert.assertTrue("outer tags preserved", result.containsKey("tags"));
+        Assert.assertTrue("linkedGadget key present",
+                result.containsKey("linkedGadget"));
+        Assert.assertNotNull(result.get("linkedGadget"));
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that {@code json("+label")} propagates the
+     * additive semantics into JSON serialization, since {@code json} delegates
+     * to {@code map}.
+     * <p>
+     * <strong>Start state:</strong> A {@link Gadget} with {@code name} and
+     * {@code tags} populated; supplier has not yet run.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Invoke {@code gadget.json("+label")}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The JSON string contains both the default
+     * {@code "name"} key and the computed {@code "label"} key; the supplier
+     * counter reflects exactly one invocation.
+     */
+    @Test
+    public void testAdditiveWithJson() {
+        Gadget gadget = new Gadget();
+        gadget.name = "alpha";
+        gadget.tags = new HashSet<>(ImmutableSet.of("x", "y"));
+
+        String json = gadget.json("+label");
+
+        Assert.assertTrue("json includes name", json.contains("\"name\""));
+        Assert.assertTrue("json includes label", json.contains("\"label\""));
+        Assert.assertEquals(1, gadget.labelInvocations.get());
+    }
+
+    /**
+     * <strong>Goal:</strong> Sanity check that the defaults-mode branch is
+     * unchanged: {@code map()} returns the default payload, and
+     * {@code map("-name")} returns the default payload minus {@code name}.
+     * <p>
+     * <strong>Start state:</strong> A {@link Gadget} with {@code name} and
+     * {@code tags} populated.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Invoke {@code gadget.map()} and {@code gadget.map("-name")}
+     * separately.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> {@code map()} contains {@code name} and
+     * {@code tags}; {@code map("-name")} contains {@code tags} but not
+     * {@code name}. Neither includes the computed {@code label}.
+     */
+    @Test
+    public void testNoPositiveKeysIsDefaultsBranch() {
+        Gadget gadget = new Gadget();
+        gadget.name = "alpha";
+        gadget.tags = new HashSet<>(ImmutableSet.of("x", "y"));
+
+        Map<String, Object> bare = gadget.map();
+        Map<String, Object> negativeOnly = gadget.map("-name");
+
+        Assert.assertTrue(bare.containsKey("name"));
+        Assert.assertTrue(bare.containsKey("tags"));
+        Assert.assertFalse(bare.containsKey("label"));
+
+        Assert.assertFalse(negativeOnly.containsKey("name"));
+        Assert.assertTrue(negativeOnly.containsKey("tags"));
+        Assert.assertFalse(negativeOnly.containsKey("label"));
+    }
+
+    /**
+     * A {@link Record} fixture with an intrinsic scalar, an intrinsic
+     * collection, a self-referential link, and a counter-instrumented
+     * {@link Computed} property. Exercises the three-mode dispatch (defaults,
+     * additive, whitelist) and the navigation-merge invariants under
+     * {@code map} and {@code json}.
+     */
+    class Gadget extends Record {
+
+        public String name;
+
+        public Set<String> tags = new HashSet<>();
+
+        public Gadget linkedGadget;
+
+        /**
+         * Tracks how many times {@link #label()} has been invoked.
+         */
+        final AtomicInteger labelInvocations = new AtomicInteger(0);
+
+        @Computed
+        public String label() {
+            labelInvocations.incrementAndGet();
+            return "label-" + name;
+        }
+    }
+}

--- a/src/test/java/com/cinchapi/runway/RecordAdditiveKeysTest.java
+++ b/src/test/java/com/cinchapi/runway/RecordAdditiveKeysTest.java
@@ -304,6 +304,38 @@ public class RecordAdditiveKeysTest extends RunwayBaseClientServerTest {
     }
 
     /**
+     * <strong>Goal:</strong> Verify that naming the same key both bare and
+     * {@code +}-prefixed resolves it exactly once. In whitelist mode the
+     * {@code +} prefix is a redundant annotation &mdash; the resolver must
+     * collapse the overlap so a {@link Computed @Computed} supplier never fires
+     * twice (and, by extension, a navigation additive never loads its linked
+     * record twice).
+     * <p>
+     * <strong>Start state:</strong> A {@link Gadget} with {@code name}
+     * populated; the computed supplier has not yet run.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Invoke {@code gadget.map("+label", "label")}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The result contains {@code label} mapped to
+     * the computed value and the supplier counter is exactly {@code 1}.
+     */
+    @Test
+    public void testBareAndAdditiveSameKeyResolvesOnce() {
+        Gadget gadget = new Gadget();
+        gadget.name = "alpha";
+
+        Map<String, Object> result = gadget.map("+label", "label");
+
+        Assert.assertEquals("label-alpha", result.get("label"));
+        Assert.assertEquals(
+                "redundant + alongside bare must not double-fire the supplier",
+                1, gadget.labelInvocations.get());
+    }
+
+    /**
      * <strong>Goal:</strong> Verify that the existing legacy oddity &mdash; a
      * mix of bare and {@code -}-prefixed keys returns only the bare keys
      * &mdash; is preserved by the three-mode dispatch. The presence of a bare

--- a/src/test/java/com/cinchapi/runway/RecordAdditiveKeysTest.java
+++ b/src/test/java/com/cinchapi/runway/RecordAdditiveKeysTest.java
@@ -237,6 +237,38 @@ public class RecordAdditiveKeysTest extends RunwayBaseClientServerTest {
     }
 
     /**
+     * <strong>Goal:</strong> Verify that the whitelist branch does not fire
+     * {@code resolveEntry} for a bare key the caller has also excluded. For a
+     * {@link Computed} property named bare and then negated, this guarantees
+     * the supplier never runs &mdash; the downstream {@code filter} would
+     * discard the resolved entry anyway, so resolving it is wasted work.
+     * <p>
+     * <strong>Start state:</strong> A freshly constructed {@link Gadget} with
+     * {@code name} populated; the computed supplier has not yet run.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Invoke {@code gadget.map("label", "-label")}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The result does not contain {@code label} and
+     * the supplier counter remains at {@code 0}.
+     */
+    @Test
+    public void testWhitelistBranchSkipsResolverForExcludedBareKey() {
+        Gadget gadget = new Gadget();
+        gadget.name = "alpha";
+
+        Map<String, Object> result = gadget.map("label", "-label");
+
+        Assert.assertFalse("label excluded", result.containsKey("label"));
+        Assert.assertEquals(
+                "supplier must not fire for a bare key the caller also"
+                        + " excluded",
+                0, gadget.labelInvocations.get());
+    }
+
+    /**
      * <strong>Goal:</strong> Verify that a single bare positive key triggers
      * whitelist mode &mdash; defaults are dropped &mdash; even when
      * {@code +}-prefixed keys are also present. {@code +} in whitelist mode

--- a/src/test/java/com/cinchapi/runway/RecordAdditiveKeysTest.java
+++ b/src/test/java/com/cinchapi/runway/RecordAdditiveKeysTest.java
@@ -202,6 +202,41 @@ public class RecordAdditiveKeysTest extends RunwayBaseClientServerTest {
     }
 
     /**
+     * <strong>Goal:</strong> Verify that a bare positive key still triggers
+     * whitelist mode when the same key is also excluded with {@code -}. The
+     * bare presence locks the call into whitelist mode; the {@code -}-prefixed
+     * twin filters the key out of the resulting whitelist, producing an empty
+     * result rather than the defaults.
+     * <p>
+     * <strong>Start state:</strong> A {@link Gadget} with {@code name} and
+     * {@code tags} populated.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Invoke {@code gadget.map("name", "-name")}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The result is empty &mdash; bare {@code name}
+     * forced whitelist mode and {@code -name} filtered it out of the whitelist.
+     * Critically, the result must <strong>not</strong> contain {@code tags}
+     * (which a defaults-mode demotion would have included).
+     */
+    @Test
+    public void testBareKeyForcesWhitelistEvenWhenSameKeyIsExcluded() {
+        Gadget gadget = new Gadget();
+        gadget.name = "alpha";
+        gadget.tags = new HashSet<>(ImmutableSet.of("x", "y"));
+
+        Map<String, Object> result = gadget.map("name", "-name");
+
+        Assert.assertFalse("name excluded by -", result.containsKey("name"));
+        Assert.assertFalse(
+                "defaults must not appear; bare key forced whitelist mode",
+                result.containsKey("tags"));
+        Assert.assertTrue("result should be empty", result.isEmpty());
+    }
+
+    /**
      * <strong>Goal:</strong> Verify that a single bare positive key triggers
      * whitelist mode &mdash; defaults are dropped &mdash; even when
      * {@code +}-prefixed keys are also present. {@code +} in whitelist mode
@@ -274,12 +309,12 @@ public class RecordAdditiveKeysTest extends RunwayBaseClientServerTest {
     }
 
     /**
-     * <strong>Goal:</strong> Verify that {@code +}-prefixed navigation keys do
-     * <strong>not</strong> erase the rest of the baseline root. This locks in
-     * the narrower-skip-predicate fix: for a navigation additive like
-     * {@code "+linkedGadget.name"}, the baseline {@code linkedGadget} entry
-     * must remain in the pool so the navigation slice merges into it rather
-     * than replacing it.
+     * <strong>Goal:</strong> Verify that a {@code +}-prefixed navigation key
+     * returns the outer record's defaults <em>and</em> a {@code linkedGadget}
+     * entry whose Map slice carries the navigation target. Both the outer
+     * defaults and the resolved slice must survive together: a regression that
+     * drops either side &mdash; outer defaults missing, the slice missing, or
+     * the slice resolved to the wrong value &mdash; should fail this test.
      * <p>
      * <strong>Start state:</strong> A {@link Gadget} with a non-null
      * {@code linkedGadget} that has both {@code name} and {@code tags}
@@ -291,15 +326,12 @@ public class RecordAdditiveKeysTest extends RunwayBaseClientServerTest {
      * </ul>
      * <p>
      * <strong>Expected:</strong> The result contains the outer record's
-     * defaults ({@code name}, {@code tags}) and contains a non-null
-     * {@code linkedGadget} entry. The result also has a way to surface the
-     * linked record's {@code name} &mdash; whether via the link being expanded
-     * inline or via the merged navigation slice. The test asserts the
-     * conservative invariant that the outer defaults survive and the
-     * {@code linkedGadget} key is present.
+     * {@code name} and {@code tags}, and a {@code linkedGadget} entry that is a
+     * {@link Map} containing {@code name} mapped to {@code "linked-alpha"}.
      */
+    @SuppressWarnings("unchecked")
     @Test
-    public void testAdditiveNavigationKeyPreservesBaselineRoot() {
+    public void testAdditiveNavigationKeyMergesIntoBaseline() {
         Gadget linked = new Gadget();
         linked.name = "linked-alpha";
         linked.tags = new HashSet<>(ImmutableSet.of("z"));
@@ -313,9 +345,60 @@ public class RecordAdditiveKeysTest extends RunwayBaseClientServerTest {
 
         Assert.assertTrue("outer name preserved", result.containsKey("name"));
         Assert.assertTrue("outer tags preserved", result.containsKey("tags"));
-        Assert.assertTrue("linkedGadget key present",
+        Object slice = result.get("linkedGadget");
+        Assert.assertTrue(
+                "linkedGadget slice should be a Map carrying the navigation"
+                        + " target, was: " + slice,
+                slice instanceof Map);
+        Assert.assertEquals("linked-alpha",
+                ((Map<String, Object>) slice).get("name"));
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that a {@code +}-prefixed navigation
+     * additive whose root is also negated is dropped <em>before</em> any
+     * resolver runs &mdash; the linked record is never traversed, its computed
+     * supplier never fires, and the excluded root is absent from the result.
+     * <p>
+     * Without the fix, {@code additive.removeAll(exclude)} only catches exact
+     * matches, so {@code "+linkedGadget.label"} survives past parsing alongside
+     * {@code "-linkedGadget"} and triggers {@code get("linkedGadget")} plus
+     * {@code linked.map("label")} before the downstream filter removes the
+     * resolved entry &mdash; a wasted load on a root the caller already
+     * excluded.
+     * <p>
+     * <strong>Start state:</strong> A {@link Gadget} whose {@code linkedGadget}
+     * is populated; the linked {@code labelInvocations} counter is {@code 0}.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Invoke
+     * {@code gadget.map("+linkedGadget.label", "-linkedGadget")}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The result does not contain
+     * {@code linkedGadget} and the linked {@code labelInvocations} counter
+     * remains at {@code 0}.
+     */
+    @Test
+    public void testNavigationAdditiveDroppedWhenRootIsExcluded() {
+        Gadget linked = new Gadget();
+        linked.name = "linked-alpha";
+
+        Gadget gadget = new Gadget();
+        gadget.name = "alpha";
+        gadget.tags = new HashSet<>(ImmutableSet.of("x", "y"));
+        gadget.linkedGadget = linked;
+
+        Map<String, Object> result = gadget.map("+linkedGadget.label",
+                "-linkedGadget");
+
+        Assert.assertFalse("excluded root must not appear",
                 result.containsKey("linkedGadget"));
-        Assert.assertNotNull(result.get("linkedGadget"));
+        Assert.assertEquals(
+                "linked record's @Computed supplier must not fire for a"
+                        + " navigation additive whose root is excluded",
+                0, linked.labelInvocations.get());
     }
 
     /**

--- a/src/test/java/com/cinchapi/runway/access/AudienceFrameAdditiveKeyAccessControlTest.java
+++ b/src/test/java/com/cinchapi/runway/access/AudienceFrameAdditiveKeyAccessControlTest.java
@@ -150,10 +150,11 @@ public class AudienceFrameAdditiveKeyAccessControlTest
      * <strong>Goal:</strong> Verify that when the same key root is supplied
      * under both bare and {@code +}, the bare presence subsumes the {@code +}
      * so the call is treated as whitelist (not additive). The result contains
-     * only the named key, not the audience's defaults.
+     * only the named key, not the audience's defaults, and the redundant
+     * {@code +} must not double-fire the supplier.
      * <p>
      * <strong>Start state:</strong> A freshly constructed {@link OpenBox} with
-     * {@code name} populated.
+     * {@code name} populated; the computed supplier has not yet run.
      * <p>
      * <strong>Workflow:</strong>
      * <ul>
@@ -164,7 +165,7 @@ public class AudienceFrameAdditiveKeyAccessControlTest
      * <strong>Expected:</strong> The result contains {@code label} but
      * <strong>not</strong> {@code name} &mdash; the bare positive forced
      * whitelist mode, and {@code name} (a non-listed default) is therefore
-     * omitted.
+     * omitted. The supplier counter is exactly {@code 1}.
      */
     @Test
     public void testFrameWithSameKeyBareAndAdditiveBareSubsumes() {
@@ -179,6 +180,9 @@ public class AudienceFrameAdditiveKeyAccessControlTest
         Assert.assertFalse(
                 "bare key forces whitelist; non-listed defaults must drop",
                 result.containsKey("name"));
+        Assert.assertEquals(
+                "redundant + alongside bare must not double-fire the supplier",
+                1, widget.labelInvocations.get());
     }
 
     /**
@@ -372,6 +376,90 @@ public class AudienceFrameAdditiveKeyAccessControlTest
     }
 
     /**
+     * <strong>Goal:</strong> Verify that mixing {@code +} and {@code -} on
+     * <em>different</em> keys under {@link AccessControl#ALL_KEYS} readable
+     * resolves as additive mode &mdash; defaults augmented with the additive
+     * and minus the user's exclusion. This exercises the
+     * {@code readable == ALL_KEYS} forwarding path in {@link Audience#frame}
+     * for a multi-prefix call.
+     * <p>
+     * <strong>Start state:</strong> A freshly constructed {@link OpenBox} with
+     * {@code name} populated; the computed supplier has not yet run.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Invoke {@code Audience.anonymous().frame(ImmutableSet.of("+label",
+     * "-name"), widget)}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The result does not contain {@code name}
+     * (excluded), contains {@code label} mapped to the computed value, and the
+     * supplier fires exactly once.
+     */
+    @Test
+    public void testFrameAdditivePlusNegativeOnDifferentKeysUnderAllKeysReadable() {
+        OpenBox widget = new OpenBox();
+        widget.name = "alpha";
+
+        Map<String, Object> result = Audience.anonymous()
+                .frame(ImmutableSet.of("+label", "-name"), widget);
+
+        Assert.assertNotNull(result);
+        Assert.assertFalse("user excluded name", result.containsKey("name"));
+        Assert.assertEquals("label-alpha", result.get("label"));
+        Assert.assertEquals(1, widget.labelInvocations.get());
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that a navigation additive
+     * ({@code "+linkedWidget.name"}) under {@link AccessControl#ALL_KEYS}
+     * readable returns the outer record's defaults <em>and</em> a
+     * {@code linkedWidget} entry whose value is a {@link Map} carrying the
+     * navigation slice. The recursive descent in {@link Audience#frame frame}
+     * must propagate the navigation suffix into the linked record without
+     * dropping the outer defaults.
+     * <p>
+     * <strong>Start state:</strong> An {@link OpenBox} with {@code name} set
+     * and {@code linkedWidget} populated by a second {@link OpenBox} whose
+     * {@code name} is {@code "linked-alpha"}.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Invoke
+     * {@code Audience.anonymous().frame(ImmutableSet.of("+linkedWidget.name"),
+     * widget)}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The result contains the outer {@code name} and
+     * a {@code linkedWidget} {@link Map} containing {@code name} mapped to
+     * {@code "linked-alpha"}.
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testFrameNavigationAdditiveUnderAllKeysReadable() {
+        OpenBox linked = new OpenBox();
+        linked.name = "linked-alpha";
+
+        OpenBox widget = new OpenBox();
+        widget.name = "alpha";
+        widget.linkedWidget = linked;
+
+        Map<String, Object> result = Audience.anonymous()
+                .frame(ImmutableSet.of("+linkedWidget.name"), widget);
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals("outer defaults preserved", "alpha",
+                result.get("name"));
+        Object slice = result.get("linkedWidget");
+        Assert.assertTrue(
+                "linkedWidget slice should be a Map carrying the navigation"
+                        + " target, was: " + slice,
+                slice instanceof Map);
+        Assert.assertEquals("linked-alpha",
+                ((Map<String, Object>) slice).get("name"));
+    }
+
+    /**
      * Base fixture providing permissive defaults for every
      * {@link AccessControl} hook except readability, which subclasses override
      * to control what an anonymous audience can see.
@@ -379,6 +467,13 @@ public class AudienceFrameAdditiveKeyAccessControlTest
     abstract static class WidgetBase extends Record implements AccessControl {
 
         public String name;
+
+        /**
+         * Optional linked widget &mdash; populated only by tests that exercise
+         * navigation. Left {@code null} by default so existing fixtures
+         * continue to serialize without an extra entry.
+         */
+        public WidgetBase linkedWidget;
 
         /**
          * Tracks how many times {@link #label()} has been invoked.

--- a/src/test/java/com/cinchapi/runway/access/AudienceFrameAdditiveKeyAccessControlTest.java
+++ b/src/test/java/com/cinchapi/runway/access/AudienceFrameAdditiveKeyAccessControlTest.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright (c) 2013-2026 Cinchapi Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.cinchapi.runway.access;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.annotation.Nonnull;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.cinchapi.runway.Computed;
+import com.cinchapi.runway.Record;
+import com.cinchapi.runway.RunwayBaseClientServerTest;
+import com.google.common.collect.ImmutableSet;
+
+/**
+ * Regression tests for the additive {@code +} key prefix on
+ * {@link Audience#frame frame}.
+ * <p>
+ * Verifies that the {@code +}-prefix survives the access-control intersection
+ * check inside {@code frame}: the prefix is stripped before matching against
+ * the audience's readable set, then re-attached when delegating to
+ * {@link Record#map map}. The prefix-strip behavior must not become a bypass
+ * &mdash; if the bare key is <em>not</em> in the audience's readable set, the
+ * {@code +key} must still be dropped.
+ *
+ * @author Jeff Nelson
+ */
+public class AudienceFrameAdditiveKeyAccessControlTest
+        extends RunwayBaseClientServerTest {
+
+    /**
+     * <strong>Goal:</strong> Verify that {@code frame({+label}, widget)} under
+     * an {@link AccessControl#ALL_KEYS} readable returns the default payload
+     * augmented with the computed {@code label}.
+     * <p>
+     * <strong>Start state:</strong> A freshly constructed {@link OpenBox} whose
+     * computed supplier has not yet run, and an anonymous {@link Audience}.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Invoke {@code Audience.anonymous().frame(ImmutableSet.of("+label"),
+     * widget)}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The result is non-null, contains {@code name}
+     * (from defaults) and {@code label} (from the additive), and the supplier
+     * counter reflects exactly one invocation.
+     */
+    @Test
+    public void testFrameWithAdditiveKeyUnderAllKeysReadable() {
+        OpenBox widget = new OpenBox();
+        widget.name = "alpha";
+
+        Map<String, Object> result = Audience.anonymous()
+                .frame(ImmutableSet.of("+label"), widget);
+
+        Assert.assertNotNull(result);
+        Assert.assertTrue("defaults include name", result.containsKey("name"));
+        Assert.assertEquals("label-alpha", result.get("label"));
+        Assert.assertEquals(1, widget.labelInvocations.get());
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that {@code frame({+label}, widget)} passes
+     * the access-control intersection when the audience's restricted readable
+     * set <em>includes</em> {@code label}, and the additive's bare-root is
+     * matched correctly after the {@code +} is stripped for the intersection
+     * check.
+     * <p>
+     * <strong>Start state:</strong> A freshly constructed
+     * {@link LabelReadableBox} whose readable-by-anonymous set is {@code {name,
+     * label}} (not {@link AccessControl#ALL_KEYS}); the computed supplier has
+     * not yet run.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Invoke {@code Audience.anonymous().frame(ImmutableSet.of("+label"),
+     * widget)}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The result is non-null and contains
+     * {@code label} mapped to the computed value; the supplier counter reflects
+     * exactly one invocation.
+     */
+    @Test
+    public void testFrameWithAdditiveKeyOnReadableField() {
+        LabelReadableBox widget = new LabelReadableBox();
+        widget.name = "alpha";
+
+        Map<String, Object> result = Audience.anonymous()
+                .frame(ImmutableSet.of("+label"), widget);
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals("label-alpha", result.get("label"));
+        Assert.assertEquals(1, widget.labelInvocations.get());
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that {@code +key} cannot bypass access
+     * control. When the audience's readable set <em>excludes</em> the
+     * additive's bare root, the {@code +key} must be dropped during the
+     * intersection check and the supplier must not fire.
+     * <p>
+     * <strong>Start state:</strong> A freshly constructed
+     * {@link LabelHiddenBox} whose readable-by-anonymous set is {@code {name}}
+     * (intentionally omitting {@code label}); the computed supplier has not yet
+     * run.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Invoke {@code Audience.anonymous().frame(ImmutableSet.of("+label"),
+     * widget)}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The result does not contain {@code label} and
+     * the supplier counter remains at {@code 0}.
+     */
+    @Test
+    public void testFrameDropsAdditiveKeyOnUnreadableField() {
+        LabelHiddenBox widget = new LabelHiddenBox();
+        widget.name = "alpha";
+
+        Map<String, Object> result = Audience.anonymous()
+                .frame(ImmutableSet.of("+label"), widget);
+
+        Assert.assertNotNull(result);
+        Assert.assertFalse("label must not bypass access control",
+                result.containsKey("label"));
+        Assert.assertEquals(0, widget.labelInvocations.get());
+    }
+
+    /**
+     * Base fixture providing permissive defaults for every
+     * {@link AccessControl} hook except readability, which subclasses override
+     * to control what an anonymous audience can see.
+     */
+    abstract static class WidgetBase extends Record implements AccessControl {
+
+        public String name;
+
+        /**
+         * Tracks how many times {@link #label()} has been invoked.
+         */
+        public final AtomicInteger labelInvocations = new AtomicInteger(0);
+
+        @Computed
+        public String label() {
+            labelInvocations.incrementAndGet();
+            return "label-" + name;
+        }
+
+        @Override
+        public boolean $isCreatableBy(@Nonnull Audience audience) {
+            return true;
+        }
+
+        @Override
+        public boolean $isCreatableByAnonymous() {
+            return true;
+        }
+
+        @Override
+        public boolean $isDeletableBy(@Nonnull Audience audience) {
+            return true;
+        }
+
+        @Override
+        public boolean $isDiscoverableBy(@Nonnull Audience audience) {
+            return true;
+        }
+
+        @Override
+        public boolean $isDiscoverableByAnonymous() {
+            return true;
+        }
+
+        @Override
+        public Set<String> $readableBy(@Nonnull Audience audience) {
+            return ALL_KEYS;
+        }
+
+        @Override
+        public Set<String> $writableBy(@Nonnull Audience audience) {
+            return ALL_KEYS;
+        }
+
+        @Override
+        public Set<String> $writableByAnonymous() {
+            return ALL_KEYS;
+        }
+
+        @Override
+        public void deleteAs(Audience audience) {
+            audience.delete(this);
+        }
+    }
+
+    /**
+     * Fixture with {@link AccessControl#ALL_KEYS} readable for any audience,
+     * including anonymous. Used to exercise the un-gated additive path through
+     * {@code frame}.
+     */
+    static class OpenBox extends WidgetBase {
+
+        @Override
+        public Set<String> $readableByAnonymous() {
+            return ALL_KEYS;
+        }
+    }
+
+    /**
+     * Fixture with a restricted readable set that includes both {@code name}
+     * and {@code label}. Used to verify that a {@code +label} additive survives
+     * the intersection check when the underlying key is in the readable
+     * allowlist.
+     */
+    static class LabelReadableBox extends WidgetBase {
+
+        @Override
+        public Set<String> $readableByAnonymous() {
+            return ImmutableSet.of("name", "label");
+        }
+    }
+
+    /**
+     * Fixture with a restricted readable set that explicitly omits
+     * {@code label}. Used to verify that a {@code +label} additive cannot
+     * bypass access control: the prefix-strip behavior must still respect the
+     * allowlist.
+     */
+    static class LabelHiddenBox extends WidgetBase {
+
+        @Override
+        public Set<String> $readableByAnonymous() {
+            return ImmutableSet.of("name");
+        }
+    }
+}

--- a/src/test/java/com/cinchapi/runway/access/AudienceFrameAdditiveKeyAccessControlTest.java
+++ b/src/test/java/com/cinchapi/runway/access/AudienceFrameAdditiveKeyAccessControlTest.java
@@ -113,6 +113,112 @@ public class AudienceFrameAdditiveKeyAccessControlTest
     }
 
     /**
+     * <strong>Goal:</strong> Verify that when the same key root is supplied
+     * under both {@code +} and {@code -}, exclusion wins &mdash; regardless of
+     * the order in which the input {@link Collection} happens to iterate. The
+     * fix relies on categorizing each input key directly into a prefix bucket
+     * during the iteration (rather than via a single per-root map, which would
+     * collapse to last-write-wins).
+     * <p>
+     * <strong>Start state:</strong> A freshly constructed {@link OpenBox} whose
+     * computed supplier has not yet run.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Invoke {@code Audience.anonymous().frame(ImmutableSet.of("+label",
+     * "-label"), widget)}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The result does not contain {@code label} (the
+     * {@code -} won) and the supplier counter remains at {@code 0} (no resolver
+     * ever fired).
+     */
+    @Test
+    public void testFrameWithSameKeyAdditiveAndNegativeExclusionWins() {
+        OpenBox widget = new OpenBox();
+        widget.name = "alpha";
+
+        Map<String, Object> result = Audience.anonymous()
+                .frame(ImmutableSet.of("+label", "-label"), widget);
+
+        Assert.assertNotNull(result);
+        Assert.assertFalse("- wins over +", result.containsKey("label"));
+        Assert.assertEquals(0, widget.labelInvocations.get());
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that when the same key root is supplied
+     * under both bare and {@code +}, the bare presence subsumes the {@code +}
+     * so the call is treated as whitelist (not additive). The result contains
+     * only the named key, not the audience's defaults.
+     * <p>
+     * <strong>Start state:</strong> A freshly constructed {@link OpenBox} with
+     * {@code name} populated.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Invoke {@code Audience.anonymous().frame(ImmutableSet.of("+label",
+     * "label"), widget)}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The result contains {@code label} but
+     * <strong>not</strong> {@code name} &mdash; the bare positive forced
+     * whitelist mode, and {@code name} (a non-listed default) is therefore
+     * omitted.
+     */
+    @Test
+    public void testFrameWithSameKeyBareAndAdditiveBareSubsumes() {
+        OpenBox widget = new OpenBox();
+        widget.name = "alpha";
+
+        Map<String, Object> result = Audience.anonymous()
+                .frame(ImmutableSet.of("+label", "label"), widget);
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals("label-alpha", result.get("label"));
+        Assert.assertFalse(
+                "bare key forces whitelist; non-listed defaults must drop",
+                result.containsKey("name"));
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify the same exclusion-wins precedence holds
+     * under a <em>restricted</em> readable set (exercising the branch that
+     * intersects the audience's allowlist with the user's request). The user's
+     * {@code -} on a key the audience would otherwise expose must still drop
+     * the key from the result.
+     * <p>
+     * <strong>Start state:</strong> A freshly constructed
+     * {@link LabelReadableBox} whose {@code $readableByAnonymous} set is
+     * {@code {name, label}}; the computed supplier has not yet run.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Invoke {@code Audience.anonymous().frame(ImmutableSet.of("+label",
+     * "-label"), widget)}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The result contains {@code name} (an audience
+     * default the user did not exclude) but not {@code label} (excluded by
+     * {@code -}); the supplier counter remains at {@code 0}.
+     */
+    @Test
+    public void testFrameWithSameKeyAdditiveAndNegativeUnderRestrictedReadable() {
+        LabelReadableBox widget = new LabelReadableBox();
+        widget.name = "alpha";
+
+        Map<String, Object> result = Audience.anonymous()
+                .frame(ImmutableSet.of("+label", "-label"), widget);
+
+        Assert.assertNotNull(result);
+        Assert.assertTrue("audience default name retained",
+                result.containsKey("name"));
+        Assert.assertFalse("- wins over + even under restricted readable",
+                result.containsKey("label"));
+        Assert.assertEquals(0, widget.labelInvocations.get());
+    }
+
+    /**
      * <strong>Goal:</strong> Verify that {@code +key} cannot bypass access
      * control. When the audience's readable set <em>excludes</em> the
      * additive's bare root, the {@code +key} must be dropped during the
@@ -144,6 +250,46 @@ public class AudienceFrameAdditiveKeyAccessControlTest
         Assert.assertFalse("label must not bypass access control",
                 result.containsKey("label"));
         Assert.assertEquals(0, widget.labelInvocations.get());
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that a {@code +}-prefixed key never
+     * re-introduces fields outside the audience's readable set. When the
+     * audience can see <em>only</em> the additive's target key and the subject
+     * has other intrinsic fields, the result must contain just the additive's
+     * target (plus {@code id}) &mdash; not the subject's full defaults.
+     * <p>
+     * Without the fix, {@code frame} re-attaches {@code +} to the key before
+     * delegating to {@code subject.map}; that switches {@code subject.map} into
+     * additive mode and pulls in the subject's intrinsic defaults, bypassing
+     * the audience allowlist.
+     * <p>
+     * <strong>Start state:</strong> A freshly constructed
+     * {@link LabelOnlyReadableBox} whose intrinsic {@code name} field is
+     * populated but whose readable-by-anonymous set is {@code {label}} only.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Invoke {@code Audience.anonymous().frame(ImmutableSet.of("+label"),
+     * widget)}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The result contains {@code label} mapped to
+     * the computed value and does <strong>not</strong> contain {@code name}
+     * (the intrinsic field excluded from the audience's readable set).
+     */
+    @Test
+    public void testFrameAdditiveDoesNotBypassRestrictedReadableDefaults() {
+        LabelOnlyReadableBox widget = new LabelOnlyReadableBox();
+        widget.name = "alpha";
+
+        Map<String, Object> result = Audience.anonymous()
+                .frame(ImmutableSet.of("+label"), widget);
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals("label-alpha", result.get("label"));
+        Assert.assertFalse("intrinsic name must not leak through `+` bypass",
+                result.containsKey("name"));
     }
 
     /**
@@ -250,6 +396,21 @@ public class AudienceFrameAdditiveKeyAccessControlTest
         @Override
         public Set<String> $readableByAnonymous() {
             return ImmutableSet.of("name");
+        }
+    }
+
+    /**
+     * Fixture with a restricted readable set that exposes <em>only</em> the
+     * computed {@code label} property, even though the subject also carries an
+     * intrinsic {@code name} field. Used to verify that a {@code +label}
+     * additive never silently re-engages additive mode on the subject and leaks
+     * {@code name} into the framed result.
+     */
+    static class LabelOnlyReadableBox extends WidgetBase {
+
+        @Override
+        public Set<String> $readableByAnonymous() {
+            return ImmutableSet.of("label");
         }
     }
 }

--- a/src/test/java/com/cinchapi/runway/access/AudienceFrameAdditiveKeyAccessControlTest.java
+++ b/src/test/java/com/cinchapi/runway/access/AudienceFrameAdditiveKeyAccessControlTest.java
@@ -219,6 +219,85 @@ public class AudienceFrameAdditiveKeyAccessControlTest
     }
 
     /**
+     * <strong>Goal:</strong> Verify that a bare positive together with a
+     * negative on the same root, under {@link AccessControl#ALL_KEYS} readable,
+     * returns an empty data set &mdash; not the subject's other defaults. The
+     * bare positive forces whitelist mode and the negative removes the only
+     * whitelisted key, so no field of the subject should appear in the result.
+     * <p>
+     * Without the fix, the audience would forward only the negative to
+     * {@code subject.map} (dropping the bare half of the request) and return
+     * {@code defaults - {name}}, leaking the subject's other intrinsic defaults
+     * past the user's whitelist intent.
+     * <p>
+     * <strong>Start state:</strong> A freshly constructed
+     * {@link MultiFieldOpenBox} with both {@code name} and {@code description}
+     * populated; readable-by-anonymous is {@link AccessControl#ALL_KEYS}.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Invoke {@code Audience.anonymous().frame(ImmutableSet.of(
+     * "name", "-name"), widget)}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The result contains neither {@code name}
+     * (excluded by {@code -name}) nor {@code description} (a default that the
+     * bare {@code name} dropped from the whitelist).
+     */
+    @Test
+    public void testFrameBareAndNegativeOnSameRootUnderAllKeysReadable() {
+        MultiFieldOpenBox widget = new MultiFieldOpenBox();
+        widget.name = "alpha";
+        widget.description = "desc";
+
+        Map<String, Object> result = Audience.anonymous()
+                .frame(ImmutableSet.of("name", "-name"), widget);
+
+        Assert.assertNotNull(result);
+        Assert.assertFalse("- wins over bare in whitelist",
+                result.containsKey("name"));
+        Assert.assertFalse(
+                "bare key forced whitelist; non-listed default must drop",
+                result.containsKey("description"));
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify the same bare-plus-same-key-negative
+     * semantics hold under a <em>restricted</em> readable set (exercising the
+     * inner whitelist sub-branch that intersects the audience's allowlist with
+     * the user's positive request). The caller's {@code -name} must reach
+     * {@code subject.map} alongside the bare {@code name} so the exclude filter
+     * applies inside whitelist mode &mdash; otherwise the negative is silently
+     * dropped and the call diverges from {@link Record#map}.
+     * <p>
+     * <strong>Start state:</strong> A freshly constructed
+     * {@link LabelReadableBox} whose readable-by-anonymous set is {@code {name,
+     * label}}.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Invoke {@code Audience.anonymous().frame(ImmutableSet.of(
+     * "name", "-name"), widget)}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The result does not contain {@code name}; the
+     * negative is honored inside whitelist mode just as it is on the
+     * {@link Record#map} side.
+     */
+    @Test
+    public void testFrameBareAndNegativeOnSameRootUnderRestrictedReadable() {
+        LabelReadableBox widget = new LabelReadableBox();
+        widget.name = "alpha";
+
+        Map<String, Object> result = Audience.anonymous()
+                .frame(ImmutableSet.of("name", "-name"), widget);
+
+        Assert.assertNotNull(result);
+        Assert.assertFalse("- wins over bare in whitelist",
+                result.containsKey("name"));
+    }
+
+    /**
      * <strong>Goal:</strong> Verify that {@code +key} cannot bypass access
      * control. When the audience's readable set <em>excludes</em> the
      * additive's bare root, the {@code +key} must be dropped during the
@@ -364,6 +443,22 @@ public class AudienceFrameAdditiveKeyAccessControlTest
      * {@code frame}.
      */
     static class OpenBox extends WidgetBase {
+
+        @Override
+        public Set<String> $readableByAnonymous() {
+            return ALL_KEYS;
+        }
+    }
+
+    /**
+     * Fixture with {@link AccessControl#ALL_KEYS} readable and a second
+     * intrinsic field beyond {@code name}. Used to detect leaks of the
+     * subject's other defaults through prefix-handling bugs in the
+     * {@link Audience#frame frame} delegation to {@link Record#map map}.
+     */
+    static class MultiFieldOpenBox extends WidgetBase {
+
+        public String description;
 
         @Override
         public Set<String> $readableByAnonymous() {

--- a/src/test/java/com/cinchapi/runway/access/AudienceFrameDenylistReadableTest.java
+++ b/src/test/java/com/cinchapi/runway/access/AudienceFrameDenylistReadableTest.java
@@ -171,6 +171,76 @@ public class AudienceFrameDenylistReadableTest
     }
 
     /**
+     * <strong>Goal:</strong> Verify that {@code +}-prefixing a denied key
+     * cannot bypass the denylist. The additive is dropped at the access-control
+     * intersection, the call is flagged as restricted, and the resulting map
+     * carries the audience's defaults minus the denied key.
+     * <p>
+     * <strong>Start state:</strong> A {@link SecretDenialBox} whose
+     * {@code $readableByAnonymous} set is {@code {"-secret"}} with both
+     * {@code name} and {@code secret} populated; the computed supplier has not
+     * yet run.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Invoke {@code Audience.anonymous().frame(ImmutableSet.of("+secret"),
+     * widget)}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The result contains {@code name} (an audience
+     * default the caller did not exclude) but does <strong>not</strong> contain
+     * {@code secret} (denied by the audience even with the {@code +} prefix).
+     * The computed supplier remains untouched.
+     */
+    @Test
+    public void testFrameDropsAdditiveOnDeniedKeyAgainstDenylistOnlyReadable() {
+        SecretDenialBox widget = new SecretDenialBox();
+        widget.name = "alpha";
+        widget.secret = "hidden";
+
+        Map<String, Object> result = Audience.anonymous()
+                .frame(ImmutableSet.of("+secret"), widget);
+
+        Assert.assertNotNull(result);
+        Assert.assertFalse("+ prefix must not bypass denylist",
+                result.containsKey("secret"));
+        Assert.assertEquals("audience default name retained", "alpha",
+                result.get("name"));
+        Assert.assertEquals(
+                "supplier must not fire for an unrequested computed key", 0,
+                widget.labelInvocations.get());
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that {@code read({"+secret"}, widget)}
+     * against a denylist-only readable throws
+     * {@link RestrictedAccessException}. A {@code +} prefix names a positive
+     * request; the audience must surface a restriction signal when that request
+     * collides with a denial, just as it does for the bare-key equivalent.
+     * <p>
+     * <strong>Start state:</strong> A {@link SecretDenialBox} whose
+     * {@code $readableByAnonymous} set is {@code {"-secret"}} with
+     * {@code secret} populated.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Invoke {@code Audience.anonymous().read(ImmutableSet.of("+secret"),
+     * widget)}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The call throws
+     * {@link RestrictedAccessException}.
+     */
+    @Test(expected = RestrictedAccessException.class)
+    public void testReadAdditiveOnDeniedKeyAgainstDenylistOnlyReadable() {
+        SecretDenialBox widget = new SecretDenialBox();
+        widget.name = "alpha";
+        widget.secret = "hidden";
+
+        Audience.anonymous().read(ImmutableSet.of("+secret"), widget);
+    }
+
+    /**
      * <strong>Goal:</strong> Verify that {@code frame(widget)} (an
      * {@link AccessControl#ALL_KEYS}-requested call) against a denylist-only
      * readable returns the subject's defaults minus the audience's denied keys.

--- a/src/test/java/com/cinchapi/runway/access/AudienceFrameDenylistReadableTest.java
+++ b/src/test/java/com/cinchapi/runway/access/AudienceFrameDenylistReadableTest.java
@@ -1,0 +1,317 @@
+/*
+ * Copyright (c) 2013-2026 Cinchapi Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.cinchapi.runway.access;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.annotation.Nonnull;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.cinchapi.runway.Computed;
+import com.cinchapi.runway.Record;
+import com.cinchapi.runway.RunwayBaseClientServerTest;
+import com.google.common.collect.ImmutableSet;
+
+/**
+ * Regression tests for {@link Audience#frame frame} against a denylist-only
+ * {@code $readableBy*()} rule (a non-{@link AccessControl#ALL_KEYS} set that
+ * contains only {@code -}-prefixed entries). The audience's semantic in this
+ * mode is "every key the subject exposes, minus the entries in the denylist",
+ * mirroring {@link AccessControlSupport#isPermittedAccess} which treats an
+ * empty allowlist as a wildcard.
+ *
+ * @author Jeff Nelson
+ */
+public class AudienceFrameDenylistReadableTest
+        extends RunwayBaseClientServerTest {
+
+    /**
+     * <strong>Goal:</strong> Verify that {@code frame({name}, widget)} against
+     * a denylist-only readable returns the named key &mdash; the audience's
+     * empty allowlist must behave as a wildcard, not a deny-all.
+     * <p>
+     * <strong>Start state:</strong> A freshly constructed
+     * {@link SecretDenialBox} whose {@code $readableByAnonymous} set is
+     * {@code {"-secret"}} (denylist-only) with {@code name} populated.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Invoke {@code Audience.anonymous().frame(ImmutableSet.of("name"),
+     * widget)}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The result contains {@code name} &mdash;
+     * dispatching whitelist mode on the audience side must not strip the key
+     * just because the audience has no positive allowlist.
+     */
+    @Test
+    public void testFrameBareKeyAgainstDenylistOnlyReadable() {
+        SecretDenialBox widget = new SecretDenialBox();
+        widget.name = "alpha";
+
+        Map<String, Object> result = Audience.anonymous()
+                .frame(ImmutableSet.of("name"), widget);
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals("alpha", result.get("name"));
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that {@code frame({+label}, widget)}
+     * against a denylist-only readable returns the audience's defaults
+     * augmented with the additive, minus the audience's denials.
+     * <p>
+     * <strong>Start state:</strong> A {@link SecretDenialBox} whose
+     * {@code $readableByAnonymous} set is {@code {"-secret"}} with {@code name}
+     * populated; the computed supplier has not yet run.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Invoke {@code Audience.anonymous().frame(ImmutableSet.of("+label"),
+     * widget)}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The result contains {@code name} (default
+     * minus the denied {@code secret}) and {@code label} (additive), and does
+     * not contain {@code secret}. The supplier fires exactly once.
+     */
+    @Test
+    public void testFrameAdditiveAgainstDenylistOnlyReadable() {
+        SecretDenialBox widget = new SecretDenialBox();
+        widget.name = "alpha";
+        widget.secret = "hidden";
+
+        Map<String, Object> result = Audience.anonymous()
+                .frame(ImmutableSet.of("+label"), widget);
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals("alpha", result.get("name"));
+        Assert.assertEquals("label-alpha", result.get("label"));
+        Assert.assertFalse("denied secret must not leak",
+                result.containsKey("secret"));
+        Assert.assertEquals(1, widget.labelInvocations.get());
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that {@code frame({-name}, widget)} against
+     * a denylist-only readable returns the audience's defaults minus both the
+     * user's exclusion and the audience's denials.
+     * <p>
+     * <strong>Start state:</strong> A {@link SecretDenialBox} whose
+     * {@code $readableByAnonymous} set is {@code {"-secret"}} with {@code name}
+     * and {@code secret} populated.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Invoke {@code Audience.anonymous().frame(ImmutableSet.of("-name"),
+     * widget)}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The result does not contain {@code name}
+     * (excluded by the user) or {@code secret} (denied by the audience).
+     */
+    @Test
+    public void testFrameNegativeAgainstDenylistOnlyReadable() {
+        SecretDenialBox widget = new SecretDenialBox();
+        widget.name = "alpha";
+        widget.secret = "hidden";
+
+        Map<String, Object> result = Audience.anonymous()
+                .frame(ImmutableSet.of("-name"), widget);
+
+        Assert.assertNotNull(result);
+        Assert.assertFalse("user excluded name", result.containsKey("name"));
+        Assert.assertFalse("audience denied secret",
+                result.containsKey("secret"));
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that {@code frame({secret}, widget)}
+     * against a denylist-only readable that denies {@code secret} drops the key
+     * from the result and flags the call as restricted.
+     * <p>
+     * <strong>Start state:</strong> A {@link SecretDenialBox} whose
+     * {@code $readableByAnonymous} set is {@code {"-secret"}} with
+     * {@code secret} populated.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Invoke {@code Audience.anonymous().read(ImmutableSet.of("secret"),
+     * widget)} and capture the thrown exception.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The call throws
+     * {@link RestrictedAccessException} &mdash; the user explicitly named a
+     * denied key, so the audience must not silently honor it.
+     */
+    @Test(expected = RestrictedAccessException.class)
+    public void testReadDeniedBareKeyAgainstDenylistOnlyReadable() {
+        SecretDenialBox widget = new SecretDenialBox();
+        widget.name = "alpha";
+        widget.secret = "hidden";
+
+        Audience.anonymous().read(ImmutableSet.of("secret"), widget);
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that {@code frame(widget)} (an
+     * {@link AccessControl#ALL_KEYS}-requested call) against a denylist-only
+     * readable returns the subject's defaults minus the audience's denied keys.
+     * This exercises the {@code requested == ALL_KEYS && readable != ALL_KEYS}
+     * forwarding path in {@link Audience#frame}.
+     * <p>
+     * <strong>Start state:</strong> A {@link SecretDenialBox} whose
+     * {@code $readableByAnonymous} set is {@code {"-secret"}} with {@code name}
+     * and {@code secret} populated.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Invoke {@code Audience.anonymous().frame(widget)}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The result contains {@code name} (default) and
+     * does not contain {@code secret} (denied by the audience).
+     */
+    @Test
+    public void testFrameAllKeysRequestAgainstDenylistOnlyReadable() {
+        SecretDenialBox widget = new SecretDenialBox();
+        widget.name = "alpha";
+        widget.secret = "hidden";
+
+        Map<String, Object> result = Audience.anonymous().frame(widget);
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals("alpha", result.get("name"));
+        Assert.assertFalse("denied secret must not leak",
+                result.containsKey("secret"));
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that {@code frame({"name", "-name"},
+     * widget)} against a denylist-only readable hits the whitelist branch (bare
+     * positive triggers) and the caller's {@code -name} removes the only
+     * whitelisted key, producing an empty data set. The audience's denials must
+     * still be honored, so the denied {@code secret} must not surface either.
+     * <p>
+     * <strong>Start state:</strong> A {@link SecretDenialBox} whose
+     * {@code $readableByAnonymous} set is {@code {"-secret"}} with both
+     * {@code name} and {@code secret} populated.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Invoke {@code Audience.anonymous().frame(ImmutableSet.of("name",
+     * "-name"), widget)}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The result contains neither {@code name}
+     * (excluded by the user) nor {@code secret} (denied by the audience) nor
+     * any other default field &mdash; the bare positive forced whitelist mode
+     * and the negative removed the only whitelisted key.
+     */
+    @Test
+    public void testFrameBareAndNegativeOnSameRootAgainstDenylistOnlyReadable() {
+        SecretDenialBox widget = new SecretDenialBox();
+        widget.name = "alpha";
+        widget.secret = "hidden";
+
+        Map<String, Object> result = Audience.anonymous()
+                .frame(ImmutableSet.of("name", "-name"), widget);
+
+        Assert.assertNotNull(result);
+        Assert.assertFalse("- removes the whitelisted name",
+                result.containsKey("name"));
+        Assert.assertFalse("denied secret must not leak",
+                result.containsKey("secret"));
+    }
+
+    /**
+     * Fixture with a denylist-only readable rule that hides the {@code secret}
+     * field. Every other intrinsic and computed field remains readable,
+     * mirroring {@link AccessControlSupport#isPermittedAccess}'s
+     * empty-allowlist-as-wildcard semantic.
+     */
+    static class SecretDenialBox extends Record implements AccessControl {
+
+        public String name;
+
+        public String secret;
+
+        /**
+         * Tracks how many times {@link #label()} has been invoked.
+         */
+        public final AtomicInteger labelInvocations = new AtomicInteger(0);
+
+        @Computed
+        public String label() {
+            labelInvocations.incrementAndGet();
+            return "label-" + name;
+        }
+
+        @Override
+        public boolean $isCreatableBy(@Nonnull Audience audience) {
+            return true;
+        }
+
+        @Override
+        public boolean $isCreatableByAnonymous() {
+            return true;
+        }
+
+        @Override
+        public boolean $isDeletableBy(@Nonnull Audience audience) {
+            return true;
+        }
+
+        @Override
+        public boolean $isDiscoverableBy(@Nonnull Audience audience) {
+            return true;
+        }
+
+        @Override
+        public boolean $isDiscoverableByAnonymous() {
+            return true;
+        }
+
+        @Override
+        public Set<String> $readableBy(@Nonnull Audience audience) {
+            return ImmutableSet.of("-secret");
+        }
+
+        @Override
+        public Set<String> $readableByAnonymous() {
+            return ImmutableSet.of("-secret");
+        }
+
+        @Override
+        public Set<String> $writableBy(@Nonnull Audience audience) {
+            return ALL_KEYS;
+        }
+
+        @Override
+        public Set<String> $writableByAnonymous() {
+            return ALL_KEYS;
+        }
+
+        @Override
+        public void deleteAs(Audience audience) {
+            audience.delete(this);
+        }
+    }
+}

--- a/src/test/java/com/cinchapi/runway/access/AudienceFrameNegativeKeyAccessControlTest.java
+++ b/src/test/java/com/cinchapi/runway/access/AudienceFrameNegativeKeyAccessControlTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2013-2026 Cinchapi Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.cinchapi.runway.access;
+
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableSet;
+
+/**
+ * Regression test demonstrating that {@link Audience#frame} silently drops
+ * {@code -}-prefixed keys when the audience's readable set is restricted (not
+ * {@link AccessControl#ALL_KEYS}).
+ * <p>
+ * The intersection check at the heart of {@code frame} compares each requested
+ * root against the audience's bare-key allowlist. A requested key like
+ * {@code "-name"} has the literal {@code -} as part of its root and never
+ * matches the bare {@code name} in the allowlist, so the exclusion is dropped
+ * and the call resolves to an empty result.
+ * </p>
+ *
+ * @author Jeff Nelson
+ */
+public class AudienceFrameNegativeKeyAccessControlTest
+        extends AudienceAccessControlBaseTest {
+
+    /**
+     * <strong>Goal:</strong> Verify that a {@code -}-prefixed key passed to
+     * {@link Audience#frame} is honored as an exclusion against the
+     * intersection of the caller's request and the audience's readable set,
+     * even when the readable set is restricted to a specific subset of fields.
+     * <p>
+     * <strong>Start state:</strong> A {@link Candidate} populated with
+     * {@code name}, {@code email}, {@code skills}, {@code yearsExperience}, and
+     * {@code location}, plus the non-readable {@code resume} field. An
+     * {@link EmployerUser} audience whose {@code $readableBy} rule for
+     * {@link Candidate} returns {@code {name, email, skills, yearsExperience,
+     * location}}, which is not {@link AccessControl#ALL_KEYS}.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Call {@code employerUser.frame(ImmutableSet.of("-name"),
+     *       candidate)}.</li>
+     * <li>Inspect the returned map for the presence of expected readable keys
+     * and the absence of {@code name}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The result is non-null and contains
+     * {@code email}, {@code skills}, {@code yearsExperience}, and
+     * {@code location} (the readable keys other than {@code name}). It does
+     * <strong>not</strong> contain {@code name} (excluded by {@code -name}) and
+     * does <strong>not</strong> contain {@code resume} (not in the readable
+     * set).
+     * <p>
+     * <strong>Current behavior:</strong> {@code -name}'s root is the literal
+     * string {@code "-name"}, which fails the intersection check against the
+     * bare-key allowlist. The visible array is empty and the method returns an
+     * empty map &mdash; the assertions on {@code email}, {@code skills},
+     * {@code yearsExperience}, and {@code location} all fail.
+     */
+    @Test
+    public void testFrameHonorsNegativeKeyAgainstRestrictedReadable() {
+        Candidate candidate = new Candidate();
+        candidate.name = "Jane Developer";
+        candidate.email = "jane@email.com";
+        candidate.skills = "Java, Python";
+        candidate.yearsExperience = 5;
+        candidate.location = "San Francisco";
+        candidate.resume = "Sensitive resume content";
+
+        EmployerUser employerUser = new EmployerUser();
+        employerUser.name = "HR Manager";
+        employerUser.email = "hr@techcorp.com";
+
+        Map<String, Object> result = employerUser
+                .frame(ImmutableSet.of("-name"), candidate);
+
+        Assert.assertNotNull("subject must be discoverable", result);
+        Assert.assertFalse("-name should exclude name",
+                result.containsKey("name"));
+        Assert.assertTrue("email is readable", result.containsKey("email"));
+        Assert.assertTrue("skills is readable", result.containsKey("skills"));
+        Assert.assertTrue("yearsExperience is readable",
+                result.containsKey("yearsExperience"));
+        Assert.assertTrue("location is readable",
+                result.containsKey("location"));
+        Assert.assertFalse("resume is not readable",
+                result.containsKey("resume"));
+    }
+
+}

--- a/src/test/java/com/cinchapi/runway/access/AudienceFrameNegativeKeyAccessControlTest.java
+++ b/src/test/java/com/cinchapi/runway/access/AudienceFrameNegativeKeyAccessControlTest.java
@@ -91,4 +91,57 @@ public class AudienceFrameNegativeKeyAccessControlTest
                 result.containsKey("resume"));
     }
 
+    /**
+     * <strong>Goal:</strong> Verify that a {@code -}-prefixed key passed to
+     * {@link Audience#frame} against an {@link AccessControl#ALL_KEYS} readable
+     * returns the subject's defaults minus the excluded key. This exercises the
+     * {@code readable == ALL_KEYS} forwarding path with a pure negative call
+     * shape, complementing the restricted-readable case in
+     * {@link #testFrameHonorsNegativeKeyAgainstRestrictedReadable}.
+     * <p>
+     * <strong>Start state:</strong> A {@link Candidate} populated with
+     * {@code name}, {@code email}, {@code skills}, {@code yearsExperience},
+     * {@code location}, and {@code resume}. An {@link Admin} audience whose
+     * {@code $readableBy} rule for {@link Candidate} returns
+     * {@link AccessControl#ALL_KEYS}.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Call {@code admin.frame(ImmutableSet.of("-name"), candidate)}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The result does not contain {@code name} but
+     * contains every other intrinsic key, including {@code resume} (which an
+     * unrestricted audience may see).
+     */
+    @Test
+    public void testFrameHonorsNegativeKeyAgainstAllKeysReadable() {
+        Candidate candidate = new Candidate();
+        candidate.name = "Jane Developer";
+        candidate.email = "jane@email.com";
+        candidate.skills = "Java, Python";
+        candidate.yearsExperience = 5;
+        candidate.location = "San Francisco";
+        candidate.resume = "Sensitive resume content";
+
+        Admin admin = new Admin();
+        admin.name = "System Admin";
+        admin.email = "admin@company.com";
+
+        Map<String, Object> result = admin.frame(ImmutableSet.of("-name"),
+                candidate);
+
+        Assert.assertNotNull("subject must be discoverable", result);
+        Assert.assertFalse("-name should exclude name",
+                result.containsKey("name"));
+        Assert.assertTrue("email is readable", result.containsKey("email"));
+        Assert.assertTrue("skills is readable", result.containsKey("skills"));
+        Assert.assertTrue("yearsExperience is readable",
+                result.containsKey("yearsExperience"));
+        Assert.assertTrue("location is readable",
+                result.containsKey("location"));
+        Assert.assertTrue("resume is readable under ALL_KEYS",
+                result.containsKey("resume"));
+    }
+
 }

--- a/src/test/java/com/cinchapi/runway/access/AudienceFrameNegativeKeyAccessControlTest.java
+++ b/src/test/java/com/cinchapi/runway/access/AudienceFrameNegativeKeyAccessControlTest.java
@@ -23,16 +23,10 @@ import org.junit.Test;
 import com.google.common.collect.ImmutableSet;
 
 /**
- * Regression test demonstrating that {@link Audience#frame} silently drops
- * {@code -}-prefixed keys when the audience's readable set is restricted (not
- * {@link AccessControl#ALL_KEYS}).
- * <p>
- * The intersection check at the heart of {@code frame} compares each requested
- * root against the audience's bare-key allowlist. A requested key like
- * {@code "-name"} has the literal {@code -} as part of its root and never
- * matches the bare {@code name} in the allowlist, so the exclusion is dropped
- * and the call resolves to an empty result.
- * </p>
+ * Regression test verifying that {@link Audience#frame} honors a
+ * {@code -}-prefixed key against an audience whose readable set is restricted
+ * (not {@link AccessControl#ALL_KEYS}). The result is the intersection of the
+ * audience's allowlist with the caller's exclusions &mdash; never an empty map.
  *
  * @author Jeff Nelson
  */
@@ -66,12 +60,6 @@ public class AudienceFrameNegativeKeyAccessControlTest
      * <strong>not</strong> contain {@code name} (excluded by {@code -name}) and
      * does <strong>not</strong> contain {@code resume} (not in the readable
      * set).
-     * <p>
-     * <strong>Current behavior:</strong> {@code -name}'s root is the literal
-     * string {@code "-name"}, which fails the intersection check against the
-     * bare-key allowlist. The visible array is empty and the method returns an
-     * empty map &mdash; the assertions on {@code email}, {@code skills},
-     * {@code yearsExperience}, and {@code location} all fail.
      */
     @Test
     public void testFrameHonorsNegativeKeyAgainstRestrictedReadable() {

--- a/src/test/java/com/cinchapi/runway/util/KeySelectionTest.java
+++ b/src/test/java/com/cinchapi/runway/util/KeySelectionTest.java
@@ -1,0 +1,329 @@
+/*
+ * Copyright (c) 2013-2026 Cinchapi Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.cinchapi.runway.util;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.cinchapi.runway.util.KeySelection.Kind;
+import com.cinchapi.runway.util.KeySelection.Partition;
+import com.cinchapi.runway.util.KeySelection.RootedPartition;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+/**
+ * Unit tests for {@link KeySelection}, the shared parser for the
+ * {@code +}/{@code -}/bare key conventions used by
+ * {@link com.cinchapi.runway.Record#map Record#map} and
+ * {@link com.cinchapi.runway.access.Audience#frame Audience#frame}.
+ *
+ * @author Jeff Nelson
+ */
+public class KeySelectionTest {
+
+    /**
+     * <strong>Goal:</strong> Verify that {@link KeySelection#kindOf(String)
+     * kindOf} returns {@link Kind#ADDITIVE} for {@code +}-prefixed keys,
+     * {@link Kind#EXCLUDE} for {@code -}-prefixed keys, and {@link Kind#BARE}
+     * for everything else.
+     * <p>
+     * <strong>Start state:</strong> No prior state needed.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Call {@code kindOf} with a {@code +}-prefixed key, a
+     * {@code -}-prefixed key, a bare key, and an empty string.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The returned {@link Kind} matches the input
+     * prefix; an empty string is {@link Kind#BARE}.
+     */
+    @Test
+    public void testKindOfClassifiesByPrefix() {
+        Assert.assertEquals(Kind.ADDITIVE, KeySelection.kindOf("+foo"));
+        Assert.assertEquals(Kind.EXCLUDE, KeySelection.kindOf("-foo"));
+        Assert.assertEquals(Kind.BARE, KeySelection.kindOf("foo"));
+        Assert.assertEquals(Kind.BARE, KeySelection.kindOf(""));
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that
+     * {@link KeySelection#stripPrefix(String) stripPrefix} removes a leading
+     * {@code +} or {@code -} and leaves all other inputs unchanged.
+     * <p>
+     * <strong>Start state:</strong> No prior state needed.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Call {@code stripPrefix} with a {@code +}-prefixed key, a
+     * {@code -}-prefixed key, a bare key, and an empty string.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The result is the input with at most one
+     * leading {@code +}/{@code -} removed; bare and empty inputs are returned
+     * unchanged.
+     */
+    @Test
+    public void testStripPrefixRemovesLeadingMarker() {
+        Assert.assertEquals("foo", KeySelection.stripPrefix("+foo"));
+        Assert.assertEquals("foo", KeySelection.stripPrefix("-foo"));
+        Assert.assertEquals("foo", KeySelection.stripPrefix("foo"));
+        Assert.assertEquals("", KeySelection.stripPrefix(""));
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that
+     * {@link KeySelection#partition(Iterable)} drops their leading prefixes
+     * onto each bucket and applies the exclusion-wins rule for both exact and
+     * root matches against {@code exclude}.
+     * <p>
+     * <strong>Start state:</strong> No prior state needed.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Partition a list containing one bare key, two additive keys whose
+     * roots are excluded by sibling {@code -} entries (one exact match, one
+     * root match against a navigation additive), and an unrelated additive that
+     * survives.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> {@code bare} contains the bare key unchanged;
+     * {@code additive} contains only the surviving additive; {@code exclude}
+     * contains the two stripped exclusions.
+     */
+    @Test
+    public void testPartitionAppliesExclusionWinsForExactAndRootMatches() {
+        Partition p = KeySelection.partition(ImmutableList.of("name", "+foo",
+                "-foo", "+bar.baz", "-bar", "+kept"));
+
+        Assert.assertEquals(ImmutableList.of("name"), p.bare());
+        Assert.assertEquals(ImmutableList.of("kept"), p.additive());
+        Assert.assertEquals(ImmutableSet.of("foo", "bar"),
+                ImmutableSet.copyOf(p.exclude()));
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that a bare key shared with an exclude
+     * entry stays in {@link Partition#bare() bare}; the exclusion-wins rule
+     * does not strip bare keys, because a bare positive must retain its power
+     * to force whitelist mode at the call site.
+     * <p>
+     * <strong>Start state:</strong> No prior state needed.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Partition a list containing the same key both bare and as an
+     * exclusion ({@code "name", "-name"}).</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> {@code bare} contains {@code name};
+     * {@code exclude} also contains {@code name}; {@code additive} is empty.
+     */
+    @Test
+    public void testPartitionBareKeyRetainsPowerWhenAlsoExcluded() {
+        Partition p = KeySelection.partition(ImmutableList.of("name", "-name"));
+
+        Assert.assertEquals(ImmutableList.of("name"), p.bare());
+        Assert.assertEquals(ImmutableList.of("name"), p.exclude());
+        Assert.assertTrue("additive should be empty", p.additive().isEmpty());
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that {@link Partition} accessors return
+     * unmodifiable views &mdash; the contract is read-only.
+     * <p>
+     * <strong>Start state:</strong> No prior state needed.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Partition any list of keys.</li>
+     * <li>Attempt to add to each of {@code bare()}, {@code additive()}, and
+     * {@code exclude()}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> Each attempted mutation throws an
+     * {@link UnsupportedOperationException}.
+     */
+    @Test
+    public void testPartitionAccessorsAreUnmodifiable() {
+        Partition p = KeySelection.partition(ImmutableList.of("a", "+b", "-c"));
+
+        try {
+            p.bare().add("x");
+            Assert.fail("bare() must be unmodifiable");
+        }
+        catch (UnsupportedOperationException expected) {/* pass */}
+        try {
+            p.additive().add("x");
+            Assert.fail("additive() must be unmodifiable");
+        }
+        catch (UnsupportedOperationException expected) {/* pass */}
+        try {
+            p.exclude().add("x");
+            Assert.fail("exclude() must be unmodifiable");
+        }
+        catch (UnsupportedOperationException expected) {/* pass */}
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that
+     * {@link KeySelection#partitionByRoot(Iterable)} buckets each input by its
+     * bare root, surfaces navigation suffixes per root, and applies the
+     * exclusion-wins rule on the bare roots.
+     * <p>
+     * <strong>Start state:</strong> No prior state needed.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Partition a list containing a bare navigation key, an additive
+     * navigation key, an exclude on a different root, and an unrelated bare
+     * key.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The bucket sets contain the bare roots (no
+     * prefix, no suffix); the navigation map carries the suffixes for every
+     * mentioned root, including an empty set for roots without a suffix.
+     */
+    @Test
+    public void testPartitionByRootBucketsBareRootsAndTracksSuffixes() {
+        RootedPartition p = KeySelection.partitionByRoot(ImmutableList
+                .of("user.name", "+company.address", "-archived", "ok"));
+
+        Assert.assertEquals(ImmutableSet.of("user", "ok"), p.bare());
+        Assert.assertEquals(ImmutableSet.of("company"), p.additive());
+        Assert.assertEquals(ImmutableSet.of("archived"), p.exclude());
+
+        Map<String, Set<String>> nav = p.navigation();
+        Assert.assertEquals(ImmutableSet.of("name"), nav.get("user"));
+        Assert.assertEquals(ImmutableSet.of("address"), nav.get("company"));
+        Assert.assertTrue("'-archived' has no suffix",
+                nav.get("archived").isEmpty());
+        Assert.assertTrue("'ok' has no suffix", nav.get("ok").isEmpty());
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that
+     * {@link KeySelection#partitionByRoot(Iterable)} drops an additive entry
+     * when its root is also excluded &mdash; including the case where the
+     * exclude entry itself carries a navigation suffix ({@code "-a.c"} is
+     * treated as a root-level exclude on {@code "a"} per the Audience
+     * convention).
+     * <p>
+     * <strong>Start state:</strong> No prior state needed.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Partition {@code "+a.b", "-a"} (root exact-match).</li>
+     * <li>Partition {@code "+a.b", "-a.c"} (root match via the exclude's own
+     * navigation key).</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> In both cases, {@code additive} is empty and
+     * {@code exclude} contains {@code a}.
+     */
+    @Test
+    public void testPartitionByRootExclusionWinsOnRootMatch() {
+        RootedPartition exact = KeySelection
+                .partitionByRoot(ImmutableList.of("+a.b", "-a"));
+        Assert.assertTrue("additive should be empty when root is excluded",
+                exact.additive().isEmpty());
+        Assert.assertEquals(ImmutableSet.of("a"), exact.exclude());
+
+        RootedPartition navExclude = KeySelection
+                .partitionByRoot(ImmutableList.of("+a.b", "-a.c"));
+        Assert.assertTrue("'-a.c' is a root-level exclude that drops '+a.b'",
+                navExclude.additive().isEmpty());
+        Assert.assertEquals(ImmutableSet.of("a"), navExclude.exclude());
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that the partition produced by
+     * {@link KeySelection#partitionByRoot(Iterable)} is order-independent
+     * &mdash; the same set of inputs in any order yields equal buckets and
+     * equal navigation maps.
+     * <p>
+     * <strong>Start state:</strong> No prior state needed.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Partition {@code ["+x", "-x"]} and {@code ["-x", "+x"]}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> Both produce empty {@code additive},
+     * {@code exclude = {x}}, and equivalent navigation maps.
+     */
+    @Test
+    public void testPartitionByRootIsOrderIndependent() {
+        RootedPartition forward = KeySelection
+                .partitionByRoot(ImmutableList.of("+x", "-x"));
+        RootedPartition reverse = KeySelection
+                .partitionByRoot(ImmutableList.of("-x", "+x"));
+
+        Assert.assertEquals(forward.bare(), reverse.bare());
+        Assert.assertEquals(forward.additive(), reverse.additive());
+        Assert.assertEquals(forward.exclude(), reverse.exclude());
+        Assert.assertTrue("additive must be empty in both",
+                forward.additive().isEmpty());
+        Assert.assertEquals(ImmutableSet.of("x"), forward.exclude());
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that {@link RootedPartition} accessors
+     * return unmodifiable views.
+     * <p>
+     * <strong>Start state:</strong> No prior state needed.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Partition any list of keys.</li>
+     * <li>Attempt to mutate {@code bare()}, {@code additive()},
+     * {@code exclude()}, and {@code navigation()}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> Each attempted mutation throws an
+     * {@link UnsupportedOperationException}.
+     */
+    @Test
+    public void testRootedPartitionAccessorsAreUnmodifiable() {
+        RootedPartition p = KeySelection
+                .partitionByRoot(ImmutableList.of("a", "+b.c", "-d"));
+
+        try {
+            p.bare().add("x");
+            Assert.fail("bare() must be unmodifiable");
+        }
+        catch (UnsupportedOperationException expected) {/* pass */}
+        try {
+            p.additive().add("x");
+            Assert.fail("additive() must be unmodifiable");
+        }
+        catch (UnsupportedOperationException expected) {/* pass */}
+        try {
+            p.exclude().add("x");
+            Assert.fail("exclude() must be unmodifiable");
+        }
+        catch (UnsupportedOperationException expected) {/* pass */}
+        try {
+            p.navigation().put("x", ImmutableSet.of("y"));
+            Assert.fail("navigation() must be unmodifiable");
+        }
+        catch (UnsupportedOperationException expected) {/* pass */}
+    }
+
+}

--- a/src/test/java/com/cinchapi/runway/util/KeySelectionTest.java
+++ b/src/test/java/com/cinchapi/runway/util/KeySelectionTest.java
@@ -326,4 +326,35 @@ public class KeySelectionTest {
         catch (UnsupportedOperationException expected) {/* pass */}
     }
 
+    /**
+     * <strong>Goal:</strong> Verify that the inner suffix {@link Set Sets}
+     * stored in {@link RootedPartition#navigation() navigation} are themselves
+     * unmodifiable &mdash; the outer-map wrapper must not leak live
+     * {@link java.util.HashSet HashSets} that would break the
+     * {@link javax.annotation.concurrent.Immutable @Immutable} contract.
+     * <p>
+     * <strong>Start state:</strong> No prior state needed.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Partition a list containing a navigation key.</li>
+     * <li>Attempt to add a suffix to the inner {@link Set} returned by
+     * {@code navigation().get(...)}.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The mutation throws an
+     * {@link UnsupportedOperationException}.
+     */
+    @Test
+    public void testRootedPartitionNavigationInnerSetsAreUnmodifiable() {
+        RootedPartition p = KeySelection
+                .partitionByRoot(ImmutableList.of("a.b"));
+
+        try {
+            p.navigation().get("a").add("c");
+            Assert.fail("navigation() inner Set must be unmodifiable");
+        }
+        catch (UnsupportedOperationException expected) {/* pass */}
+    }
+
 }


### PR DESCRIPTION
## Summary

Adds a `+` key prefix to `Record#map`, `Record#json`, and
`Audience#frame` that includes the named key on top of the
defaults &mdash; the escape hatch for layering a single
`@Computed` property without enumerating every other key.

The dispatch is three-mode and driven by the shape of the key
list:

- **Defaults** (no positive keys): `defaults − exclude`
- **Additive** (only `+` positives): `(defaults ∪ additive) − exclude`
- **Whitelist** (any bare positive): `(bare ∪ additive) − exclude`

In whitelist mode the `+` prefix degrades to a redundant
annotation: any bare key drops the defaults, so `+`-prefixed
keys become just another whitelisted entry. Every legacy call
shape is preserved.

The PR also closes a latent bug in `Audience#frame`: a
`-`-prefixed key against any restricted (non-`ALL_KEYS`)
readable set silently collapsed the result to an empty map.
The same prefix-aware parsing that enables `+` also fixes that
case so the audience's readable set is honored as defaults
when the user only uses `+` or `-`.

Issue: [#133](https://github.com/cinchapi/runway/issues/133)

## Test plan

- [ ] `./gradlew spotlessApply` &mdash; clean
- [ ] `./gradlew compileJava compileTestJava` &mdash; clean
- [ ] New tests pass:
    - `RecordAdditiveKeysTest` (10 tests &mdash; three-mode dispatch, collection no-duplicate, navigation merge, JSON delegation)
    - `AudienceFrameAdditiveKeyAccessControlTest` (3 tests &mdash; `+` propagation under ALL_KEYS, restricted-readable that includes the field, restricted-readable that excludes it)
    - `AudienceFrameNegativeKeyAccessControlTest` (1 test &mdash; the latent `-`-prefix bug under restricted readable)
- [ ] Existing tests remain green, including:
    - `RecordDataAccessTest#testGetNegativeAndPositiveFiltering` (legacy whitelist-with-negatives oddity)
    - `RecordIncludeComputedValuesTest` (`@Computed` laziness)
    - `AudienceAccessControlFrameTest` (frame intersection)
    - `AudienceFrameOptionsTest` (options threading)
