### PR TITLE
Resolve the concrete class when loading a record by an abstract class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+#### Version 2.1.1 (TBD)
+* Fixed a bug where loading a record by id through an abstract class with no scanned descendants (most importantly, the `Record` base class itself via `load(Record.class, id)`) threw `InstantiationException` instead of resolving the record's concrete class from its stored section. ([GH-145](https://github.com/cinchapi/runway/issues/145))
+* Loading a record by id through an abstract class now returns `null` when the id does not name a Runway record (its data has no class section), consistent with how invalid records are indistinguishable from invisible ones. ([GH-145](https://github.com/cinchapi/runway/issues/145))
+
 #### Version 2.1.0 (May 22, 2026)
 * Fixed a bug where loading an access-controlled `Record` through an `Audience` (e.g., `Audience#load(Class, long)`) threw `UnsupportedOperationException` when the class's registered visibility `Scope` used a scoped navigation criteria (`Criteria.where().scope(prefix, inner)`). ([GH-125](https://github.com/cinchapi/runway/issues/125))
 * **Breaking change:** `@Computed` properties are no longer materialized by `Record#map()`, `Record#json()`, or `Audience#frame()` unless the caller positively names them. The `@Computed` annotation has always promised that "computed data is generally expensive to generate and should only be calculated when explicitly requested" &mdash; but the historical default materialized every `@Computed` property on any bare serialization call, eagerly invoking suppliers the caller never asked for. That behavior contradicted the annotation's contract and made `@Computed` operationally indistinguishable from `@Derived`. This release corrects the longstanding bug by aligning the default with the documented contract. ([GH-128](https://github.com/cinchapi/runway/issues/128))

--- a/src/main/java/com/cinchapi/runway/Runway.java
+++ b/src/main/java/com/cinchapi/runway/Runway.java
@@ -17,6 +17,7 @@ package com.cinchapi.runway;
 
 import static com.cinchapi.runway.DatabaseInterface.duplicateEntryException;
 
+import java.lang.reflect.Modifier;
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1729,10 +1730,13 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
         Realms realms = selection.realms;
         Predicate<T> filter = selection.filter;
         boolean hasFilter = !DatabaseSelection.isNoFilter(filter);
-        // The provided clazz has descendants, so it is possible that the
-        // Record with the #id is actually a member of a subclass.
-        boolean needsSectionLookup = StaticAnalysis.instance()
-                .getClassHierarchy(initialClazz).size() > 1;
+        // The provided clazz has descendants (or is abstract, so the stored
+        // record can only be an instance of a descendant), which means the
+        // Record with the #id may actually be a member of a subclass.
+        boolean needsSectionLookup = Modifier
+                .isAbstract(initialClazz.getModifiers())
+                || StaticAnalysis.instance().getClassHierarchy(initialClazz)
+                        .size() > 1;
         Set<String> paths = needsSectionLookup ? null
                 : getPathsForClassIfSupported(initialClazz);
         Pending<Map<String, Set<Object>>> data = paths != null
@@ -1759,6 +1763,12 @@ public final class Runway implements AutoCloseable, DatabaseInterface {
                 if(sections != null && !sections.isEmpty()) {
                     String section = (String) Iterables.getLast(sections);
                     clazz = Reflection.getClassCasted(section);
+                }
+                else if(Modifier.isAbstract(clazz.getModifiers())) {
+                    // Without a section, an abstract clazz can never be
+                    // instantiated, so treat the record as invalid and make it
+                    // indistinguishable from one that is not visible.
+                    return Pending.of(new SelectResult<>(null));
                 }
             }
             if(!realms.names().isEmpty()) {

--- a/src/test/java/com/cinchapi/runway/GH145.java
+++ b/src/test/java/com/cinchapi/runway/GH145.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2013-2026 Cinchapi Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.cinchapi.runway;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.cinchapi.concourse.time.Time;
+
+/**
+ * Regression tests for
+ * <a href="https://github.com/cinchapi/runway/issues/145">GH-145</a>: loading a
+ * record by id through an abstract class (most importantly, {@link Record}
+ * itself) must resolve the record's concrete class instead of throwing
+ * {@code InstantiationException}.
+ *
+ * @author Jeff Nelson
+ */
+public class GH145 extends RunwayBaseClientServerTest {
+
+    /**
+     * <strong>Goal:</strong> Verify that {@code load(Record.class, id)}
+     * resolves the stored record's concrete class.
+     * <p>
+     * <strong>Start state:</strong> A saved {@link Player}.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Load the record by id with {@link Record} as the requested
+     * class.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The loaded record is a {@link Player} with its
+     * saved state intact.
+     */
+    @Test
+    public void testLoadByRecordClassResolvesConcreteClass() {
+        Player player = new Player("Magic Johnson", 25);
+        runway.save(player);
+
+        Record record = runway.load(Record.class, player.id());
+
+        Assert.assertTrue(record instanceof Player);
+        Assert.assertEquals("Magic Johnson", ((Player) record).name);
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that {@code load(Record.class, id)}
+     * resolves a record to its most specific class, not just any concrete
+     * ancestor.
+     * <p>
+     * <strong>Start state:</strong> A saved {@link PointGuard}, which is a
+     * subclass of {@link Player}.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Load the record by id with {@link Record} as the requested
+     * class.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The loaded record is a {@link PointGuard} with
+     * its subclass state intact.
+     */
+    @Test
+    public void testLoadByRecordClassResolvesMostSpecificClass() {
+        PointGuard pointGuard = new PointGuard("John Stockton", 13, 15);
+        runway.save(pointGuard);
+
+        Record record = runway.load(Record.class, pointGuard.id());
+
+        Assert.assertTrue(record instanceof PointGuard);
+        Assert.assertEquals(15, ((PointGuard) record).assists);
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that {@code load(Record.class, id)} returns
+     * {@code null} for an id that names no record.
+     * <p>
+     * <strong>Start state:</strong> No prior state needed.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Load a never-used id with {@link Record} as the requested class.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The load returns {@code null} without
+     * throwing.
+     */
+    @Test
+    public void testLoadByRecordClassWithUnknownIdReturnsNull() {
+        Assert.assertNull(runway.load(Record.class, Time.now()));
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that {@code load(Record.class, id)} returns
+     * {@code null} for an id whose data was not written by Runway and therefore
+     * has no class section.
+     * <p>
+     * <strong>Start state:</strong> A raw Concourse record written directly
+     * through the client.
+     * <p>
+     * <strong>Workflow:</strong>
+     * <ul>
+     * <li>Add data to an id with {@code client.add(...)}.</li>
+     * <li>Load that id with {@link Record} as the requested class.</li>
+     * </ul>
+     * <p>
+     * <strong>Expected:</strong> The load returns {@code null} without
+     * throwing, consistent with how invalid records are indistinguishable from
+     * invisible ones.
+     */
+    @Test
+    public void testLoadByRecordClassOfNonRunwayRecordReturnsNull() {
+        long id = Time.now();
+        client.add("name", "not a runway record", id);
+
+        Assert.assertNull(runway.load(Record.class, id));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes [GH-145](https://github.com/cinchapi/runway/issues/145): loading a
record by id through an abstract class threw `InstantiationException`
instead of resolving the record's concrete class. The most important case
is the `Record` base class itself, which is the natural target when a
caller must resolve an id into whatever record it names without knowing
the class in advance.

## Behavior

- `load(Class, long)` with an abstract class now resolves the stored
  record's concrete class and returns an instance of it, including the
  most specific subclass when the record belongs to a deeper hierarchy.
- When the id names no record, the load returns `null`, as before.
- When the id names data that is not a Runway record (it has no class
  section), a load through an abstract class now returns `null` instead
  of failing on instantiation, consistent with the existing contract that
  invalid records are indistinguishable from invisible ones.
- Loads through concrete classes, and through abstract classes whose
  descendants are on the classpath, behave exactly as before.

## Scope

- Only the single-record load-by-id path changes. Class loads, finds, and
  searches already resolve each record's class from its stored section
  and are untouched.
- No public API is added or changed.
- `GH145` holds the regression tests. The changelog carries the fix under
  a 2.1.1 patch entry.
